### PR TITLE
feat: add REGISTRATION_ENABLED env variable to disable new account creation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,6 @@ JWT_SECRET=replace-me-with-a-long-random-secret
 
 # CORS Origins (comma-separated)
 CORS_ORIGINS=http://localhost:5173,http://localhost:3000
+
+# Registration (set to false to disable new account creation)
+REGISTRATION_ENABLED=true

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -7,6 +7,7 @@ import { Users } from 'lucide-react';
 
 const Login: React.FC = () => {
     const { login, register } = useAuth();
+    const registrationEnabled = import.meta.env.VITE_REGISTRATION_ENABLED !== 'false';
     const [isLogin, setIsLogin] = useState(true);
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
@@ -115,19 +116,21 @@ const Login: React.FC = () => {
                         </Button>
                     </form>
 
-                    <div className="mt-8 text-center pt-2 border-t border-border">
-                        <button
-                            onClick={() => {
-                                setIsLogin(!isLogin);
-                                setError('');
-                            }}
-                            className="text-body-sm text-nexus-blue hover:text-nexus-blue/80 font-medium transition-colors hover:underline underline-offset-4"
-                        >
-                            {isLogin
-                                ? "Je n'ai pas de compte, m'inscrire"
-                                : 'J\'ai déjà un compte, me connecter'}
-                        </button>
-                    </div>
+                    {registrationEnabled && (
+                        <div className="mt-8 text-center pt-2 border-t border-border">
+                            <button
+                                onClick={() => {
+                                    setIsLogin(!isLogin);
+                                    setError('');
+                                }}
+                                className="text-body-sm text-nexus-blue hover:text-nexus-blue/80 font-medium transition-colors hover:underline underline-offset-4"
+                            >
+                                {isLogin
+                                    ? "Je n'ai pas de compte, m'inscrire"
+                                    : 'J\'ai déjà un compte, me connecter'}
+                            </button>
+                        </div>
+                    )}
                 </CardContent>
             </Card>
 

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -22,6 +22,10 @@ router.get('/me', authMiddleware, async (req: AuthRequest, res) => {
 
 // Register
 router.post('/register', async (req, res) => {
+    if (process.env.REGISTRATION_ENABLED === 'false') {
+        return res.status(403).json({ success: false, error: 'Registration is disabled' });
+    }
+
     try {
         const { email, password, name } = req.body;
         const normalizedEmail = typeof email === 'string' ? normalizeEmail(email) : '';


### PR DESCRIPTION
Quand on mets la variable à false, le serveur retourne une erreur 403 sur la route POST /api/auth/register et le client cache l'url de création de compte.

Par défaut la valeur est à true pour garder l'état actuel.