### PR TITLE
feat(i18n): add Simplified Chinese localization

### DIFF
--- a/client/src/components/ui/LanguageSwitcher.tsx
+++ b/client/src/components/ui/LanguageSwitcher.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '../../lib/utils';
 import { SUPPORTED_LANGUAGES } from '../../i18n';
+import { LANGUAGE_CONFIG } from '../../i18n/languages';
 import { changeAppLanguage } from '../../lib/language';
 import { useToast } from './Toast';
+import { useAuth } from '../../contexts/AuthContext';
 
 interface LanguageSwitcherProps {
     className?: string;
@@ -12,13 +14,29 @@ interface LanguageSwitcherProps {
 export const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ className }) => {
     const { i18n, t } = useTranslation('common');
     const { showToast } = useToast();
+    const { user, updateCurrency } = useAuth();
     const current = (i18n.resolvedLanguage || i18n.language || 'en').split('-')[0];
 
     const handleChange = (lng: string) => {
-        // Fire-and-forget server sync; only surface an error toast on failure.
-        void changeAppLanguage(lng).then((synced) => {
+        void (async () => {
+            const synced = await changeAppLanguage(lng);
             if (!synced) showToast({ title: t('language.syncError') });
-        });
+
+            const currencyDefault = LANGUAGE_CONFIG[lng]?.currencyDefault;
+            if (user && currencyDefault) {
+                const shouldApplyCurrencyDefault = user.currency
+                    ? currencyDefault.replace.includes(user.currency)
+                    : currencyDefault.replaceMissing;
+
+                if (shouldApplyCurrencyDefault) {
+                    try {
+                        await updateCurrency(currencyDefault.with);
+                    } catch {
+                        showToast({ title: t('language.currencySyncError') });
+                    }
+                }
+            }
+        })();
     };
 
     return (
@@ -43,7 +61,7 @@ export const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ className })
                             : 'text-muted-foreground hover:text-foreground'
                     )}
                 >
-                    {lng}
+                    {LANGUAGE_CONFIG[lng]?.label ?? lng.toUpperCase()}
                 </button>
             ))}
         </div>

--- a/client/src/demo/mockApi.ts
+++ b/client/src/demo/mockApi.ts
@@ -294,7 +294,7 @@ async function route(method: string, path: string, q: Record<string, string>, bo
         return ok({ token: 'demo-token', user: store.user });
     if (path === '/api/auth/currency') { store.user = { ...store.user, currency: body.currency }; return ok({ user: store.user }); }
     if (path === '/api/auth/language') {
-        if (body.language !== 'fr' && body.language !== 'en') throw new Error('Invalid language'); // mirrors the server's 400
+        if (body.language !== 'fr' && body.language !== 'en' && body.language !== 'zh') throw new Error('Invalid language'); // mirrors the server's 400
         store.user = { ...store.user, language: body.language };
         return ok({ user: store.user });
     }

--- a/client/src/i18n/format.ts
+++ b/client/src/i18n/format.ts
@@ -1,12 +1,12 @@
 import type { Locale } from 'date-fns';
-import { enUS, fr, es, de, it, pt, nl } from 'date-fns/locale';
+import { enUS, fr, es, de, it, pt, nl, zhCN } from 'date-fns/locale';
 import i18n from './index';
 
 // date-fns locales for the languages we may ship. Adding a new app language
 // only needs an extra entry here (falls back to English otherwise).
-const DATE_LOCALES: Record<string, Locale> = { en: enUS, fr, es, de, it, pt, nl };
+const DATE_LOCALES: Record<string, Locale> = { en: enUS, fr, es, de, it, pt, nl, zh: zhCN };
 // BCP-47 tags for Intl.* — falls back to the bare language code.
-const INTL_TAGS: Record<string, string> = { en: 'en-US', fr: 'fr-FR' };
+const INTL_TAGS: Record<string, string> = { en: 'en-US', fr: 'fr-FR', zh: 'zh-CN' };
 
 const lang = () => (i18n.language || 'en').split('-')[0];
 

--- a/client/src/i18n/index.ts
+++ b/client/src/i18n/index.ts
@@ -1,6 +1,7 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
+import { CONFIGURED_LANGUAGE_ORDER } from './languages';
 
 // Auto-import every locale file: ./locales/<lng>/<namespace>.json
 // Dropping a new JSON file in that folder is enough — no manual wiring needed.
@@ -20,12 +21,12 @@ for (const filePath in modules) {
 
 // Languages are discovered from the locale folders themselves: to add a new
 // language, just drop a `locales/<lng>/` folder of JSON files — it appears in
-// the switcher automatically. `en` and `fr` are listed first, the rest A→Z.
-const PREFERRED_ORDER = ['en', 'fr'];
+// the switcher automatically. Configured languages are listed first in config
+// order, followed by unconfigured locale folders A→Z.
 const discovered = Object.keys(resources);
 export const SUPPORTED_LANGUAGES: string[] = [
-    ...PREFERRED_ORDER.filter((l) => discovered.includes(l)),
-    ...discovered.filter((l) => !PREFERRED_ORDER.includes(l)).sort(),
+    ...CONFIGURED_LANGUAGE_ORDER.filter((l) => discovered.includes(l)),
+    ...discovered.filter((l) => !CONFIGURED_LANGUAGE_ORDER.includes(l)).sort(),
 ];
 
 const namespaces = Array.from(

--- a/client/src/i18n/languages.ts
+++ b/client/src/i18n/languages.ts
@@ -1,0 +1,30 @@
+export interface LanguageConfig {
+    label: string;
+    currencyDefault?: {
+        replace: readonly string[];
+        with: string;
+        replaceMissing?: boolean;
+    };
+}
+
+// UI metadata and optional locale defaults for configured languages. Locale
+// folders remain the source of truth for availability; an unconfigured folder
+// still appears in the switcher with its language code as the label.
+export const LANGUAGE_CONFIG: Record<string, LanguageConfig> = {
+    en: {
+        label: 'EN',
+    },
+    fr: {
+        label: 'FR',
+    },
+    zh: {
+        label: '中文',
+        currencyDefault: {
+            replace: ['EUR'],
+            with: 'CNY',
+            replaceMissing: true,
+        },
+    },
+};
+
+export const CONFIGURED_LANGUAGE_ORDER = Object.keys(LANGUAGE_CONFIG);

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -6,7 +6,8 @@
     "star": "Star on GitHub"
   },
   "language": {
-    "syncError": "Could not save your language preference."
+    "syncError": "Could not save your language preference.",
+    "currencySyncError": "Could not update the default currency."
   },
   "actions": {
     "add": "Add",

--- a/client/src/i18n/locales/fr/common.json
+++ b/client/src/i18n/locales/fr/common.json
@@ -6,7 +6,8 @@
     "star": "Mettre une étoile sur GitHub"
   },
   "language": {
-    "syncError": "Impossible d'enregistrer votre préférence de langue."
+    "syncError": "Impossible d'enregistrer votre préférence de langue.",
+    "currencySyncError": "Impossible de mettre à jour la devise par défaut."
   },
   "actions": {
     "add": "Ajouter",

--- a/client/src/i18n/locales/zh/ai.json
+++ b/client/src/i18n/locales/zh/ai.json
@@ -1,0 +1,72 @@
+{
+  "magic": {
+    "open": "AI 助手",
+    "title": "AI 助手 ✨",
+    "description": "描述你想添加的内容，助手会处理其余工作。",
+    "placeholder": "添加周四晚上的千层面，并提醒小明带健身包……",
+    "parse": "分析",
+    "parsing": "正在分析……",
+    "nothingFound": "未在这条内容中找到可执行事项，请尝试换种说法。",
+    "back": "返回",
+    "reviewHint": "检查建议，取消勾选不需要的项目，然后确认。",
+    "confirm": "添加（{{count}}）",
+    "confirming": "正在添加……",
+    "successTitle": "完成 ✨",
+    "successDescription": "已添加 {{count}} 个项目。",
+    "partialTitle": "部分添加成功",
+    "partialDescription": "已添加 {{added}} 个，{{failed}} 个失败。",
+    "allFailed": "没有项目被添加，请重试。",
+    "types": {
+      "task": "任务",
+      "appointment": "日程",
+      "shopping_item": "购物",
+      "budget_entry": "预算"
+    }
+  },
+  "meals": {
+    "button": "推荐菜单 ✨",
+    "dialogTitle": "晚餐建议",
+    "dialogDescription": "{{start}} 至 {{end}} 这一周，根据你的食谱推荐。",
+    "loading": "助手正在编排菜单……",
+    "empty": "本周所有晚餐都已安排。",
+    "confirm": "添加到计划（{{count}}）",
+    "successTitle": "菜单已添加 ✨",
+    "successDescription": "已安排 {{count}} 顿晚餐。",
+    "partialTitle": "部分添加成功",
+    "partialDescription": "已添加 {{added}} 个，{{failed}} 个失败。"
+  },
+  "settings": {
+    "title": "AI 助手",
+    "subtitle": "连接本地或云端 AI 模型，用自然语言添加事项并获取菜单建议。",
+    "provider": "服务提供商",
+    "providers": {
+      "ollama": "Ollama（本地）",
+      "openai": "OpenAI 兼容 API",
+      "anthropic": "Anthropic Claude"
+    },
+    "baseUrl": "服务器 URL",
+    "apiKey": "API 密钥",
+    "keyKept": "•••（已保留）",
+    "clearKey": "清除已保存的密钥",
+    "model": "模型",
+    "enabled": "启用助手",
+    "privacy": "隐私说明：API 密钥经过加密，仅存储在你的服务器上。使用 Ollama 时，任何内容都不会离开家中，笔记会在本地处理。",
+    "parentOnly": "只有家长可以更改这些设置。",
+    "save": "保存",
+    "saving": "正在保存……",
+    "saved": "设置已保存。",
+    "test": "测试连接",
+    "testing": "正在测试……",
+    "testSuccess": "连接成功，模型响应正常。"
+  },
+  "errors": {
+    "AI_NOT_CONFIGURED": "尚未配置 AI 助手，请前往“设置”。",
+    "AI_DISABLED": "AI 助手已在“设置”中停用。",
+    "AI_UNREACHABLE": "无法连接 AI 服务提供商，请检查 URL 及服务是否正在运行。",
+    "AI_UNAUTHORIZED": "API 密钥被拒绝，请在“设置”中检查。",
+    "AI_MODEL_NOT_FOUND": "服务提供商中未找到该模型，请检查模型名称（例如 llama3.1）。",
+    "AI_INVALID_RESPONSE": "模型返回了无效响应，请重试或切换模型。",
+    "AI_PROVIDER_ERROR": "AI 服务提供商返回错误，请重试。",
+    "AI_NOT_ENOUGH_RECIPES": "请至少添加 5 份食谱，以便助手编排菜单。"
+  }
+}

--- a/client/src/i18n/locales/zh/auth.json
+++ b/client/src/i18n/locales/zh/auth.json
@@ -1,0 +1,40 @@
+{
+  "tagline": "让科技服务于家庭纽带",
+  "login": {
+    "submit": "登录",
+    "noAccount": "没有账号，立即注册",
+    "haveAccount": "已有账号，立即登录"
+  },
+  "register": {
+    "submit": "注册"
+  },
+  "fields": {
+    "fullName": "姓名",
+    "fullNamePlaceholder": "例如：张三",
+    "email": "电子邮箱",
+    "emailPlaceholder": "you@email.com",
+    "password": "密码",
+    "roleLabel": "家庭角色",
+    "roleParent": "家长",
+    "roleChild": "孩子"
+  },
+  "invite": {
+    "banner": "你已受邀加入一个家庭！创建账号即可接受邀请。",
+    "title": "加入家庭",
+    "loggedInAs": "当前登录账号",
+    "checking": "正在检查邀请……",
+    "missing": "缺少邀请链接。",
+    "invalid": "邀请无效或已过期。",
+    "cannotVerify": "无法验证邀请。",
+    "joinError": "加入家庭时出错。",
+    "joined": "你已加入 {{name}} 的家庭！",
+    "redirecting": "正在跳转……",
+    "invitationFrom": "邀请人",
+    "expiresOn": "有效期至 {{date}}",
+    "shareWarning": "加入后，你将与 {{name}} 共享家庭数据（任务、购物、日历、预算等）。",
+    "join": "加入",
+    "joining": "正在加入……",
+    "notFound": "未找到邀请。"
+  },
+  "footer": "信任与安全"
+}

--- a/client/src/i18n/locales/zh/budget.json
+++ b/client/src/i18n/locales/zh/budget.json
@@ -1,0 +1,100 @@
+{
+  "loading": "正在加载预算……",
+  "categories": {
+    "Logement": "住房",
+    "Alimentation": "食品杂货",
+    "Transport": "交通",
+    "Santé": "健康",
+    "Loisirs": "休闲",
+    "Abonnements": "订阅",
+    "Assurance": "保险",
+    "Enfants": "子女",
+    "Maison": "家居",
+    "Autre": "其他",
+    "Prélèvements": "定期扣款"
+  },
+  "readOnly": "只读模式。只有家长可以编辑预算。",
+  "alerts": {
+    "title": "已达到限额",
+    "over": " · 已超出",
+    "warn": "（≥ 80%）"
+  },
+  "balance": {
+    "current": "当前余额",
+    "pointed_one": "已标记 {{count}} 笔扣款",
+    "pointed_other": "已标记 {{count}} 笔扣款",
+    "expenses_one": "{{count}} 笔支出",
+    "expenses_other": "{{count}} 笔支出"
+  },
+  "forecast": {
+    "title": "预测",
+    "subtitle": "还有 {{amount}} 的扣款待标记"
+  },
+  "analytics": "分析与限额",
+  "charts": {
+    "expensesByCategory": "按类别统计支出",
+    "noExpenses": "本月暂无支出",
+    "yearEvolution": "年度趋势",
+    "income": "收入",
+    "expenses": "支出",
+    "recurring": "定期扣款"
+  },
+  "limits": {
+    "title": "每月限额",
+    "subtitle": "按类别跟踪支出",
+    "define": "设置",
+    "none": "未设置限额"
+  },
+  "sections": {
+    "recurring": "定期扣款",
+    "expenses": "支出",
+    "income": "收入"
+  },
+  "recurring": {
+    "empty": "暂无定期扣款",
+    "addOne": "+ 添加扣款",
+    "markOn": "标记为已扣款",
+    "markOff": "取消标记",
+    "dayPrefix": "每月"
+  },
+  "empty": {
+    "expenses": "本月暂无支出",
+    "income": "本月暂无收入"
+  },
+  "sheets": {
+    "recurringEdit": "编辑扣款",
+    "recurringNew": "新建扣款",
+    "edit": "编辑",
+    "newExpense": "新增支出",
+    "newIncome": "新增收入",
+    "limit": "每月限额"
+  },
+  "toggle": {
+    "expense": "支出",
+    "income": "收入"
+  },
+  "fields": {
+    "name": "扣款名称",
+    "namePlaceholder": "例如：房租、电费、Netflix……",
+    "amount": "金额（{{currency}}）",
+    "debitDay": "每月扣款日（1 至 31）",
+    "debitDayPlaceholder": "例如：5",
+    "description": "说明（可选）",
+    "descriptionPlaceholder": "例如：食品杂货、工资……",
+    "date": "日期",
+    "category": "类别",
+    "limit": "每月限额（{{currency}}）",
+    "limitHint": "设为 0 可取消对此类别的跟踪。"
+  },
+  "errors": {
+    "amountInvalid": "金额无效。",
+    "nameRequired": "必须填写名称。",
+    "debitDayInvalid": "扣款日无效（1-31）。",
+    "save": "保存时出错。",
+    "limitInvalid": "限额无效。"
+  },
+  "confirm": {
+    "deleteRecurring": "删除这笔定期扣款？",
+    "deleteEntry": "删除这条记录？"
+  }
+}

--- a/client/src/i18n/locales/zh/calendar.json
+++ b/client/src/i18n/locales/zh/calendar.json
@@ -1,0 +1,60 @@
+{
+  "loading": "正在加载日历……",
+  "title": "日历",
+  "subtitle": "管理家庭日程",
+  "exportIcal": "导出（iCal）",
+  "newAppointment": "新建日程",
+  "moreOthers": "另有 {{count}} 项",
+  "upcoming": {
+    "title": "即将开始的日程",
+    "empty": "暂无即将开始的日程"
+  },
+  "dialog": {
+    "editTitle": "编辑日程",
+    "createTitle": "新建日程",
+    "description": "填写日程详情"
+  },
+  "form": {
+    "title": "标题",
+    "titlePlaceholder": "例如：医生预约",
+    "description": "说明（可选）",
+    "descriptionPlaceholder": "更多详情……",
+    "scheduling": "时间安排",
+    "startDate": "开始日期",
+    "startTime": "开始时间",
+    "endDate": "结束日期",
+    "endTime": "结束时间",
+    "location": "地点（可选）",
+    "locationPlaceholder": "例如：医生诊所",
+    "members": "家庭成员（可选）",
+    "noMembersHint": "添加成员后即可快速指派。",
+    "goToFamily": "前往“家庭”",
+    "reminders": "提醒",
+    "reminder30": "提前 30 分钟",
+    "reminder1h": "提前 1 小时",
+    "notes": "备注（可选）",
+    "notesPlaceholder": "更多备注……"
+  },
+  "feed": {
+    "title": "导出日历（iCal）",
+    "description": "通过 Apple 日历、Google 日历或 Outlook 订阅，自动同步你的日程。",
+    "generating": "正在生成链接……",
+    "subscribeLink": "订阅链接",
+    "subscribeApple": "订阅（Apple / Outlook）",
+    "downloadIcs": "下载 .ics 文件",
+    "privateNote": "此链接为私密链接：任何拥有链接的人都可以查看你的日程。",
+    "regenerate": "重新生成链接"
+  },
+  "confirmDelete": "确定要删除这项日程吗？",
+  "confirmRegen": "重新生成链接？现有订阅将停止工作。",
+  "errors": {
+    "loadAppointments": "无法加载日程。",
+    "loadMembers": "无法加载成员。",
+    "icalFetch": "无法获取 iCal 链接。",
+    "icalRegen": "无法重新生成链接。",
+    "startRequired": "请输入开始日期和时间。",
+    "endAfterStart": "结束时间必须晚于开始时间。",
+    "save": "无法保存此日程。",
+    "delete": "无法删除此日程。"
+  }
+}

--- a/client/src/i18n/locales/zh/categories.json
+++ b/client/src/i18n/locales/zh/categories.json
@@ -1,0 +1,25 @@
+{
+  "title": "类别",
+  "subtitle": "自定义购物、食谱和预算使用的类别列表。重命名类别会同步更新现有项目。",
+  "parentOnly": "只有家长可以编辑类别。",
+  "modules": {
+    "shopping": "购物",
+    "recipe": "食谱",
+    "budget": "预算"
+  },
+  "addPlaceholder": "新类别……",
+  "add": "添加",
+  "save": "保存",
+  "saved": "类别已保存。",
+  "reset": "取消更改",
+  "moveUp": "上移",
+  "moveDown": "下移",
+  "remove": "移除",
+  "hintReassign": "已移除类别中的项目将移至“{{fallback}}”。",
+  "errors": {
+    "empty": "类别名称不能为空。",
+    "duplicate": "类别重复：{{name}}",
+    "atLeastOne": "请至少保留一个类别。",
+    "save": "无法保存类别。"
+  }
+}

--- a/client/src/i18n/locales/zh/common.json
+++ b/client/src/i18n/locales/zh/common.json
@@ -1,0 +1,66 @@
+{
+  "appName": "OpenFamily",
+  "demo": {
+    "notice": "演示模式——更改不会保存，并会在重新加载后重置。",
+    "reset": "重置",
+    "star": "在 GitHub 上加星"
+  },
+  "language": {
+    "syncError": "无法保存语言偏好。",
+    "currencySyncError": "无法更新默认货币。"
+  },
+  "actions": {
+    "add": "添加",
+    "edit": "编辑",
+    "delete": "删除",
+    "cancel": "取消",
+    "save": "保存",
+    "saveChanges": "保存更改",
+    "close": "关闭",
+    "confirm": "确认",
+    "create": "创建",
+    "update": "更新",
+    "search": "搜索",
+    "filter": "筛选",
+    "back": "返回",
+    "today": "今天",
+    "retry": "重试",
+    "apply": "应用",
+    "reset": "重置",
+    "export": "导出",
+    "import": "导入",
+    "clear": "清除",
+    "send": "发送",
+    "loadMore": "加载更多"
+  },
+  "states": {
+    "loading": "正在加载……",
+    "saving": "正在保存……",
+    "empty": "这里暂时没有内容",
+    "error": "发生错误"
+  },
+  "labels": {
+    "name": "名称",
+    "fullName": "姓名",
+    "description": "说明",
+    "date": "日期",
+    "time": "时间",
+    "startTime": "开始时间",
+    "endTime": "结束时间",
+    "location": "地点",
+    "notes": "备注",
+    "category": "类别",
+    "quantity": "数量",
+    "price": "价格",
+    "amount": "金额",
+    "email": "电子邮箱",
+    "password": "密码",
+    "optional": "可选",
+    "all": "全部",
+    "none": "无"
+  },
+  "days": ["星期一", "星期二", "星期三", "星期四", "星期五", "星期六", "星期日"],
+  "daysShort": ["周一", "周二", "周三", "周四", "周五", "周六", "周日"],
+  "months": ["一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"],
+  "monthsShort": ["1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月"]
+}

--- a/client/src/i18n/locales/zh/dashboard.json
+++ b/client/src/i18n/locales/zh/dashboard.json
@@ -1,0 +1,36 @@
+{
+  "heading": {
+    "before": "你的",
+    "highlight": "一天",
+    "after": "，一目了然。"
+  },
+  "budgetAlert": {
+    "title": "预算警告",
+    "message_one": "{{count}} 个类别已超出每月预算。",
+    "message_other": "{{count}} 个类别已超出每月预算。",
+    "cta": "查看详情"
+  },
+  "stats": {
+    "appointments": "日程",
+    "tasks": "任务",
+    "shopping": "购物",
+    "monthExpenses": "本月支出"
+  },
+  "today": {
+    "title": "今天",
+    "viewWeek": "查看本周",
+    "emptyTitle": "暂无安排。",
+    "emptySubtitle": "添加日程后会显示在这里。",
+    "emptyCta": "添加日程"
+  },
+  "aside": {
+    "shopping": "购物",
+    "shoppingCount_one": "件待购商品",
+    "shoppingCount_other": "件待购商品",
+    "budget": "本月预算",
+    "budgetSubtitle": "本月已支出",
+    "tasks": "待办任务",
+    "tasksCount_one": "项待完成任务",
+    "tasksCount_other": "项待完成任务"
+  }
+}

--- a/client/src/i18n/locales/zh/family.json
+++ b/client/src/i18n/locales/zh/family.json
@@ -1,0 +1,122 @@
+{
+  "loading": "正在加载家庭……",
+  "title": "家庭",
+  "subtitle": "管理家庭成员",
+  "addMember": "添加成员",
+  "empty": "暂无家庭成员，添加第一位成员吧！",
+  "roles": {
+    "Parent": "家长",
+    "Enfant": "孩子",
+    "Etudiant": "学生",
+    "Autre": "其他"
+  },
+  "colors": {
+    "coral": "珊瑚色",
+    "orange": "橙色",
+    "yellow": "黄色",
+    "green": "绿色",
+    "cyan": "青色",
+    "blue": "蓝色",
+    "indigo": "靛蓝色",
+    "pink": "粉色"
+  },
+  "card": {
+    "age_one": "{{count}} 岁",
+    "age_other": "{{count}} 岁",
+    "health": "健康",
+    "allergies": "过敏：",
+    "medications": "药物：",
+    "emergency": "紧急联系人"
+  },
+  "shared": {
+    "title": "共享账号",
+    "subtitle": "与其他账号共享你的家庭数据。",
+    "you": "（你）",
+    "owner": "所有者",
+    "child": "🧒 孩子",
+    "parent": "👨 家长",
+    "none": "目前没有其他账号共享此家庭。",
+    "roleParent": "家长",
+    "roleChild": "孩子",
+    "roleTitle": "成员角色",
+    "transferTitle": "将所有权转让给此账号",
+    "kickTitle": "移除此账号"
+  },
+  "link": {
+    "label": "关联账号",
+    "none": "未关联账号",
+    "hint": "将此档案关联到共享账号：孩子账号将能看到自己的储蓄罐和目标。"
+  },
+  "requests": {
+    "title": "访问请求",
+    "accept": "接受",
+    "rejectTitle": "拒绝"
+  },
+  "myRequest": {
+    "pendingTitle": "等待处理的请求",
+    "sentTo": "已发送给 {{name}}（{{email}}）"
+  },
+  "join": {
+    "title": "加入家庭",
+    "desc": "输入你想加入的家庭所有者邮箱，对方将收到请求并决定接受或拒绝。",
+    "rejected": "你上次的请求已被拒绝。",
+    "emailPlaceholder": "email@example.com",
+    "sending": "正在发送……",
+    "send": "发送请求",
+    "emailRequired": "必须填写电子邮箱地址"
+  },
+  "invite": {
+    "roleLabel": "邀请身份",
+    "generate": "生成邀请链接",
+    "generating": "正在生成……",
+    "copyTitle": "复制"
+  },
+  "leave": {
+    "leaving": "正在退出……",
+    "leave": "退出共享家庭"
+  },
+  "dialog": {
+    "editTitle": "编辑成员",
+    "addTitle": "添加成员",
+    "description": "填写家庭成员详情"
+  },
+  "form": {
+    "name": "姓名",
+    "namePlaceholder": "例如：张三",
+    "role": "角色",
+    "color": "颜色",
+    "birthdate": "出生日期（可选）",
+    "healthInfo": "健康信息",
+    "allergies": "过敏项（用逗号分隔）",
+    "allergiesPlaceholder": "例如：花生、乳糖",
+    "medications": "药物（用逗号分隔）",
+    "medicationsPlaceholder": "例如：阿司匹林、胰岛素",
+    "emergencyContact": "紧急联系人",
+    "contactName": "联系人姓名",
+    "contactNamePlaceholder": "例如：李四",
+    "contactPhone": "联系电话",
+    "contactPhonePlaceholder": "例如：+86 138 0000 0000",
+    "notes": "备注（可选）",
+    "notesPlaceholder": "更多备注……"
+  },
+  "confirm": {
+    "kick": "将此账号移出家庭？",
+    "transfer": "将家庭所有权转让给 {{name}}？\n\n你将成为普通成员。所有家庭数据都会保留，并由新的所有者管理。此操作无法撤销。",
+    "delete": "确定要删除这位家庭成员吗？",
+    "leave": "退出共享家庭？之后你将恢复自己的独立数据。"
+  },
+  "errors": {
+    "load": "无法加载家庭。",
+    "save": "无法保存此成员。",
+    "delete": "无法删除此成员。",
+    "kick": "无法移除此成员。",
+    "role": "无法更改角色。",
+    "transfer": "无法转让所有权。",
+    "leave": "无法退出家庭。",
+    "invite": "无法创建邀请链接。",
+    "cancelRequest": "无法取消请求。",
+    "sendRequest": "无法发送请求。",
+    "approve": "无法接受请求。",
+    "reject": "无法拒绝请求。"
+  }
+}

--- a/client/src/i18n/locales/zh/integrations.json
+++ b/client/src/i18n/locales/zh/integrations.json
@@ -1,0 +1,86 @@
+{
+  "title": "集成",
+  "subtitle": "连接你的自托管应用，集中管理食谱、菜单、购物和日历。",
+  "connected": "已连接",
+  "available": "可用",
+  "status": {
+    "error": "错误",
+    "connected": "已连接"
+  },
+  "lastSync": "同步于 {{date}}",
+  "syncTitle": "同步",
+  "disconnectTitle": "断开连接",
+  "confirmDisconnect": "断开此集成？",
+  "modal": {
+    "connect": "连接 {{name}}",
+    "test": "测试",
+    "testing": "正在测试……",
+    "connecting": "正在连接……",
+    "connectBtn": "连接",
+    "encrypted": "凭据使用 AES-256 加密，并且只存储在你的服务器上。",
+    "error": "错误"
+  },
+  "syncs": {
+    "recipes": "食谱",
+    "menus": "菜单",
+    "shopping": "购物清单",
+    "stock": "库存",
+    "calendar": "日历",
+    "appointments": "日程",
+    "photos": "照片"
+  },
+  "catalog": {
+    "mealie": {
+      "tagline": "食谱管理器",
+      "description": "从自托管的 Mealie 实例导入食谱和菜单。",
+      "urlLabel": "实例 URL",
+      "urlPlaceholder": "https://mealie.mydomain.com",
+      "keyLabel": "API 密钥",
+      "keyPlaceholder": "在 Mealie > 个人资料 > API 密钥中获取"
+    },
+    "tandoor": {
+      "tagline": "食谱簿",
+      "description": "从开源管理器 Tandoor 导入食谱。",
+      "urlLabel": "实例 URL",
+      "urlPlaceholder": "https://tandoor.mydomain.com",
+      "keyLabel": "API 令牌",
+      "keyPlaceholder": "在 Tandoor > 设置 > 令牌中获取"
+    },
+    "homeassistant": {
+      "tagline": "智能家居",
+      "description": "将购物清单与 Home Assistant 清单同步。",
+      "urlLabel": "实例 URL",
+      "urlPlaceholder": "http://homeassistant.local:8123",
+      "tokenLabel": "长期访问令牌",
+      "tokenPlaceholder": "eyJ……（在个人资料 > 安全中获取）",
+      "entityLabel": "待办实体（可选）",
+      "entityPlaceholder": "todo.shopping_list"
+    },
+    "grocy": {
+      "tagline": "家庭管理",
+      "description": "同步 Grocy 中的购物清单和库存。",
+      "urlLabel": "实例 URL",
+      "urlPlaceholder": "https://grocy.mydomain.com",
+      "keyLabel": "API 密钥",
+      "keyPlaceholder": "在 Grocy > 管理 > API 密钥中获取"
+    },
+    "nextcloud": {
+      "tagline": "个人云",
+      "description": "将 Nextcloud 日历事件导入你的日程。",
+      "urlLabel": "Nextcloud URL",
+      "urlPlaceholder": "https://cloud.mydomain.com",
+      "userLabel": "用户名",
+      "userPlaceholder": "your.username",
+      "passwordLabel": "密码（或应用密码）",
+      "passwordPlaceholder": "****"
+    },
+    "immich": {
+      "tagline": "照片库",
+      "description": "在信息屏背景中随机显示自托管 Immich 照片库中的照片。",
+      "urlLabel": "实例 URL",
+      "urlPlaceholder": "https://immich.mydomain.com",
+      "keyLabel": "API 密钥",
+      "keyPlaceholder": "在 Immich > 账号设置 > API 密钥中获取"
+    }
+  }
+}

--- a/client/src/i18n/locales/zh/kakeibo.json
+++ b/client/src/i18n/locales/zh/kakeibo.json
@@ -1,0 +1,33 @@
+{
+  "mode": {
+    "classic": "经典",
+    "kakeibo": "家计簿"
+  },
+  "availableTitle": "可支配金额",
+  "availableSub": "收入 {{income}} − 储蓄目标 {{goal}}",
+  "spentSoFar": "已支出：{{amount}}",
+  "householdIncome": "家庭收入",
+  "extraIncome": "本月额外收入",
+  "totalIncome": "总收入",
+  "savingsGoal": "储蓄目标",
+  "pillarsTitle": "钱花到哪里了？",
+  "pillars": {
+    "survival": "生存",
+    "wants": "享受",
+    "culture": "成长",
+    "extra": "额外"
+  },
+  "pillarHint": {
+    "survival": "生活必需",
+    "wants": "兴趣享受",
+    "culture": "自我成长",
+    "extra": "意外支出"
+  },
+  "noExpenses": "本月暂无支出记录。",
+  "reviewTitle": "月末回顾",
+  "actualSavings": "实际储蓄",
+  "goalReached": "已达成目标，并超出 {{amount}}！",
+  "goalMissed": "距离目标还差 {{amount}}。",
+  "notesLabel": "复盘笔记",
+  "notesPlaceholder": "哪些方面做得好？下个月可以如何改进？"
+}

--- a/client/src/i18n/locales/zh/kiosk.json
+++ b/client/src/i18n/locales/zh/kiosk.json
@@ -1,0 +1,36 @@
+{
+  "exit": "退出",
+  "fullscreen": "全屏",
+  "exitFullscreen": "退出全屏",
+  "schedule": "今日日程",
+  "meals": "今日餐食",
+  "tasks": "今日待办",
+  "whereabouts": "今日家庭成员去向",
+  "shopping": "购物清单",
+  "allDay": "全天",
+  "undo": "撤销",
+  "empty": {
+    "appointments": "今天暂无安排",
+    "meals": "暂无餐食安排",
+    "tasks": "所有任务都完成了 ✨",
+    "whereabouts": "今天没有成员行程",
+    "shopping": "没有待购商品"
+  },
+  "displaySettings": {
+    "open": "显示设置",
+    "title": "显示设置",
+    "close": "关闭",
+    "location": "天气地点",
+    "searchPlaceholder": "搜索城市……",
+    "noResults": "没有结果",
+    "noLocation": "选择一个地点，在此信息屏上显示天气。",
+    "change": "更改",
+    "photoBackground": "照片背景",
+    "photoBackgroundHint": "随机显示照片库中的照片作为背景，需要连接 Immich 集成。"
+  },
+  "settings": {
+    "title": "信息屏",
+    "subtitle": "适用于壁挂平板或冰箱屏幕的全屏只读视图，展示今日日历、餐食、任务和家庭成员去向。",
+    "open": "打开信息屏"
+  }
+}

--- a/client/src/i18n/locales/zh/meals.json
+++ b/client/src/i18n/locales/zh/meals.json
@@ -1,0 +1,51 @@
+{
+  "loading": "正在加载餐食计划……",
+  "title": "餐食计划",
+  "subtitle": "规划本周餐食",
+  "thisWeek": "本周",
+  "weekOf": "{{start}} 至 {{end}} 这一周",
+  "mealTypes": {
+    "Petit-déjeuner": "早餐",
+    "Déjeuner": "午餐",
+    "Dîner": "晚餐",
+    "Snack": "加餐"
+  },
+  "dialog": {
+    "editTitle": "编辑餐食",
+    "addTitle": "添加餐食",
+    "descriptionFmt": "{{type}} — {{date}}"
+  },
+  "form": {
+    "mealType": "餐食类型",
+    "recipe": "食谱（可选）",
+    "noRecipe": "不使用食谱",
+    "customMeal": "或自定义餐食",
+    "customMealPlaceholder": "例如：自制披萨",
+    "notes": "备注（可选）",
+    "notesPlaceholder": "更多备注……"
+  },
+  "shopping": {
+    "button": "将食材添加到购物清单",
+    "dialogTitle": "将食材添加到购物清单",
+    "dialogDescription": "{{start}} 至 {{end}} 期间计划食谱中的食材。取消勾选不需要的食材。",
+    "empty": "本周没有安排包含食谱的餐食。",
+    "selectedCount": "已选择 {{selected}}/{{total}} 种食材",
+    "alreadyOnList": "已在清单中",
+    "confirm_one": "添加 {{count}} 种食材",
+    "confirm_other": "添加 {{count}} 种食材",
+    "successTitle": "食材已添加",
+    "successDescription_one": "已向购物清单添加 {{count}} 个项目。",
+    "successDescription_other": "已向购物清单添加 {{count}} 个项目。",
+    "partialTitle": "部分食材未能添加",
+    "partialDescription": "已添加 {{added}} 个，{{failed}} 个失败。",
+    "errorTitle": "无法添加食材",
+    "errorDescription": "没有项目添加到购物清单，请重试。"
+  },
+  "confirmDelete": "确定要删除这项餐食吗？",
+  "errors": {
+    "loadPlans": "无法加载餐食计划。",
+    "loadRecipes": "无法加载食谱。",
+    "save": "无法保存此餐食。",
+    "delete": "无法删除此餐食。"
+  }
+}

--- a/client/src/i18n/locales/zh/nav.json
+++ b/client/src/i18n/locales/zh/nav.json
@@ -1,0 +1,42 @@
+{
+  "items": {
+    "today": "今天",
+    "shopping": "购物",
+    "tasks": "任务",
+    "rewards": "零用钱",
+    "calendar": "日程",
+    "planning": "计划",
+    "recipes": "食谱",
+    "meals": "餐食",
+    "budget": "预算",
+    "family": "家庭",
+    "integrations": "集成",
+    "settings": "设置"
+  },
+  "mobile": {
+    "home": "首页",
+    "planning": "计划",
+    "lists": "清单",
+    "budget": "预算",
+    "family": "家庭"
+  },
+  "quickActions": {
+    "title": "快捷操作",
+    "addShopping": "添加待购商品",
+    "addTask": "添加任务",
+    "addAppointment": "添加日程",
+    "addSchedule": "添加计划条目",
+    "addRecipe": "添加食谱",
+    "addMeal": "添加餐食",
+    "addExpense": "添加支出",
+    "addMember": "添加成员"
+  },
+  "user": {
+    "profile": "个人资料",
+    "toggleTheme": "切换主题",
+    "logout": "退出登录",
+    "openMenu": "打开菜单"
+  },
+  "offline": "当前处于离线模式，显示的数据来自缓存。恢复连接后即可继续更改。",
+  "pageTitleFallback": "首页"
+}

--- a/client/src/i18n/locales/zh/notes.json
+++ b/client/src/i18n/locales/zh/notes.json
@@ -1,0 +1,35 @@
+{
+  "title": "家庭便签",
+  "add": "添加便签",
+  "addTitle": "新建冰箱便签",
+  "placeholder": "别忘了带健身包！",
+  "counter": "{{count}}/{{max}}",
+  "colorLabel": "颜色",
+  "colors": {
+    "yellow": "黄色",
+    "pink": "粉色",
+    "blue": "蓝色",
+    "green": "绿色",
+    "orange": "橙色"
+  },
+  "expiryLabel": "有效期",
+  "expiry": {
+    "today": "今晚到期",
+    "day": "24 小时",
+    "week": "1 周",
+    "never": "永不过期"
+  },
+  "submit": "贴上便签",
+  "cancel": "取消",
+  "delete": "移除此便签",
+  "deleted": "便签已从冰箱移除",
+  "added": "便签已贴到冰箱上",
+  "emptyHint": "给家人留张小便签，它会显示在这里和信息屏上。",
+  "by": "{{name}} 留言",
+  "age": {
+    "now": "刚刚",
+    "minutes": "{{count}} 分钟前",
+    "hours": "{{count}} 小时前",
+    "days": "{{count}} 天前"
+  }
+}

--- a/client/src/i18n/locales/zh/notifications.json
+++ b/client/src/i18n/locales/zh/notifications.json
@@ -1,0 +1,17 @@
+{
+  "title": "通知",
+  "markAll": "全部标为已读",
+  "empty": "暂无通知",
+  "manage": "管理通知 →",
+  "timeAgo": {
+    "justNow": "刚刚",
+    "minutes": "{{count}} 分钟前",
+    "hours": "{{count}} 小时前",
+    "days": "{{count}} 天前"
+  },
+  "push": {
+    "unsupported": "此浏览器不支持推送通知",
+    "denied": "权限被拒绝",
+    "noVapid": "VAPID 密钥不可用"
+  }
+}

--- a/client/src/i18n/locales/zh/planning.json
+++ b/client/src/i18n/locales/zh/planning.json
@@ -1,0 +1,70 @@
+{
+  "loading": "正在加载计划……",
+  "noMembers": {
+    "title": "请先添加家庭成员",
+    "subtitle": "每周计划以家庭成员档案为基础。",
+    "cta": "前往“家庭”"
+  },
+  "title": "每周计划",
+  "subtitle": "按周管理重复的工作时间和课程安排。",
+  "newEntry": "新建条目",
+  "thisWeek": "本周",
+  "allMembers": "所有成员",
+  "allTypes": "所有类型",
+  "types": {
+    "work": "工作",
+    "school": "上学",
+    "study": "学习",
+    "activity": "活动",
+    "other": "其他"
+  },
+  "add": "添加",
+  "nextDayShort": "+1天",
+  "dayFallback": "第 {{n}} 天",
+  "dialog": {
+    "editTitle": "编辑条目",
+    "createTitle": "新建条目",
+    "description": "定义条目并应用到一天或多天。"
+  },
+  "form": {
+    "member": "成员",
+    "type": "类型",
+    "title": "标题",
+    "titlePlaceholder": "例如：办公室 - 产品团队 / 数学课",
+    "days": "适用日期",
+    "weekdays": "周一至周五",
+    "fullWeek": "整周",
+    "selectedDay": "已选择：{{day}}",
+    "selectedDays": "已选择 {{count}} 天",
+    "start": "开始",
+    "end": "结束",
+    "nextDayHint": "于次日结束（+1 天）",
+    "thisWeekOnlyStrong": "仅本周",
+    "thisWeekOnlyRest": "。此条目仅适用于 {{date}} 所在的一周，否则将每周重复。",
+    "replaceConflicts": "替换所选日期中冲突的条目。如果存在冲突但未开启此选项，将跳过这些日期。",
+    "location": "地点（可选）",
+    "locationPlaceholder": "例如：上海办公室 / 第一中学",
+    "notes": "备注（可选）",
+    "notesPlaceholder": "实用信息、教室、科目、交通等……"
+  },
+  "submit": {
+    "applyToDays": "应用到所选日期"
+  },
+  "notice": {
+    "saved": "条目已保存。",
+    "savedDays_one": "已保存到 {{count}} 天。",
+    "savedDays_other": "已保存到 {{count}} 天。",
+    "savedDaysConflicts_one": "已保存到 {{count}} 天。以下日期存在冲突：{{days}}。",
+    "savedDaysConflicts_other": "已保存到 {{count}} 天。以下日期存在冲突：{{days}}。"
+  },
+  "confirmDelete": "删除此条目？",
+  "errors": {
+    "loadMembers": "无法加载成员。",
+    "loadEntries": "无法加载计划。",
+    "deleteEntry": "无法删除此条目。",
+    "memberTitleRequired": "必须填写成员和标题。",
+    "timesSame": "开始时间和结束时间不能相同。",
+    "selectDay": "请至少选择一天。",
+    "save": "无法保存此条目。"
+  }
+}

--- a/client/src/i18n/locales/zh/recipes.json
+++ b/client/src/i18n/locales/zh/recipes.json
@@ -1,0 +1,95 @@
+{
+  "loading": "正在加载食谱……",
+  "title": "食谱",
+  "subtitle": "你的家庭食谱库",
+  "newRecipe": "新建食谱",
+  "categories": {
+    "Entrée": "前菜",
+    "Plat": "主菜",
+    "Dessert": "甜点",
+    "Snack": "小吃"
+  },
+  "difficulties": {
+    "Facile": "简单",
+    "Moyen": "中等",
+    "Difficile": "困难"
+  },
+  "durations": {
+    "under15": "≤ 15 分钟",
+    "under30": "≤ 30 分钟",
+    "under60": "≤ 1 小时",
+    "over60": "> 1 小时"
+  },
+  "searchPlaceholder": "搜索食谱……",
+  "allCategories": "所有类别",
+  "allDifficulties": "所有难度",
+  "anyDuration": "不限时长",
+  "empty": {
+    "none": "还没有食谱，创建第一份食谱吧！",
+    "noMatch": "没有符合搜索条件的食谱。"
+  },
+  "card": {
+    "min": "{{n}} 分钟",
+    "servings_one": "{{count}} 人份",
+    "servings_other": "{{count}} 人份",
+    "view": "查看"
+  },
+  "dialog": {
+    "editTitle": "编辑食谱",
+    "createTitle": "新建食谱",
+    "description": "填写食谱详情"
+  },
+  "form": {
+    "name": "食谱名称",
+    "namePlaceholder": "例如：苹果派",
+    "category": "类别",
+    "difficulty": "难度",
+    "description": "说明（可选）",
+    "descriptionPlaceholder": "食谱简介……",
+    "prep": "准备（分钟）",
+    "prepPlaceholder": "30",
+    "cook": "烹饪（分钟）",
+    "cookPlaceholder": "45",
+    "servings": "份数",
+    "servingsPlaceholder": "4",
+    "ingredients": "食材（每行一种）",
+    "ingredientsPlaceholder": "200 克面粉\n3 个鸡蛋\n100 克糖",
+    "instructions": "步骤（每行一步）",
+    "instructionsPlaceholder": "烤箱预热至 180°C\n混合面粉和糖\n加入鸡蛋",
+    "tags": "标签（用逗号分隔）",
+    "tagsPlaceholder": "素食、快手、省钱",
+    "image": "图片 URL（可选）",
+    "imagePlaceholder": "https://…"
+  },
+  "import": {
+    "button": "从链接导入",
+    "title": "导入食谱",
+    "description": "粘贴食谱页面链接（Marmiton、750g、博客等），我们会自动填写表单。",
+    "urlLabel": "食谱页面 URL",
+    "urlPlaceholder": "https://www.marmiton.org/recettes/…",
+    "submit": "导入",
+    "importing": "正在导入……",
+    "successTitle": "食谱已导入",
+    "successDescription": "检查详情后保存。",
+    "errors": {
+      "notFoundTitle": "未找到食谱",
+      "notFound": "此页面中没有可读取的食谱。",
+      "fetchTitle": "导入失败",
+      "fetch": "无法获取此页面，请检查链接后重试。"
+    }
+  },
+  "detail": {
+    "prep": "准备：",
+    "cook": "烹饪：",
+    "servings": "份数：",
+    "minUnit": "分钟",
+    "ingredients": "食材",
+    "instructions": "步骤"
+  },
+  "confirmDelete": "确定要删除这份食谱吗？",
+  "errors": {
+    "load": "无法加载食谱。",
+    "save": "无法保存此食谱。",
+    "delete": "无法删除此食谱。"
+  }
+}

--- a/client/src/i18n/locales/zh/rewards.json
+++ b/client/src/i18n/locales/zh/rewards.json
@@ -1,0 +1,86 @@
+{
+  "loading": "正在加载零用钱……",
+  "title": "零用钱",
+  "subtitle": "完成家务赚积分，积分可以兑换零用钱",
+  "empty": "还没有奖励，先给任务添加星星吧！",
+  "streak_one": "已连续 {{count}} 天",
+  "streak_other": "已连续 {{count}} 天",
+  "pendingCount_one": "{{count}} 项待处理",
+  "pendingCount_other": "{{count}} 项待处理",
+  "worth": "价值 {{amount}}",
+  "approvals": {
+    "title_one": "{{count}} 项任务待批准",
+    "title_other": "{{count}} 项任务待批准",
+    "approve": "批准",
+    "reject": "拒绝"
+  },
+  "actions": {
+    "adjust": "调整",
+    "redeem": "兑换"
+  },
+  "types": {
+    "earn": "获得积分",
+    "adjust": "积分调整",
+    "redeem": "已兑换零用钱"
+  },
+  "fields": {
+    "note": "备注（可选）"
+  },
+  "adjustDialog": {
+    "title": "调整 {{name}} 的积分",
+    "description": "添加奖励或扣除积分（输入负数）",
+    "points": "积分（+ 或 −）",
+    "notePlaceholder": "例如：帮忙整理了买回来的商品"
+  },
+  "redeemDialog": {
+    "title": "为 {{name}} 兑换零用钱",
+    "description": "可用余额：{{balance}} 积分",
+    "points": "要兑换的积分",
+    "amount": "兑换金额：{{amount}}",
+    "notePlaceholder": "例如：存钱罐、看电影……"
+  },
+  "goals": {
+    "add": "添加目标",
+    "editTitle": "编辑目标",
+    "progress": "{{current}} / {{target}}",
+    "markAchieved": "目标已达成 🎉"
+  },
+  "goalDialog": {
+    "addTitle": "为 {{name}} 新建目标",
+    "editTitle": "编辑 {{name}} 的目标",
+    "description": "用积分实现的储蓄目标",
+    "emoji": "表情符号",
+    "titleLabel": "标题",
+    "titlePlaceholder": "例如：电子游戏",
+    "target": "目标金额（{{currency}}）",
+    "delete": "删除"
+  },
+  "kid": {
+    "hello": "你好，{{name}}！",
+    "subtitle": "这是你的存钱罐",
+    "reached": "太棒了，你做到了！🎉",
+    "reachedHint": "请家长确认你的目标。",
+    "missing": "还差 {{amount}}",
+    "editGoal": "编辑我的目标",
+    "noGoal": "你还没有目标，选一个想实现的愿望吧！",
+    "addGoal": "选择我的目标",
+    "tasksTitle": "你的任务",
+    "allTasks": "查看全部",
+    "tasksEmpty": "现在没有任务，做得好！🎉",
+    "pendingBadge": "等待批准",
+    "historyTitle": "最近动态",
+    "notLinkedTitle": "你的存钱罐在等你！",
+    "notLinkedMessage": "请家长在“家庭”页面将你的账号关联到个人档案，以查看积分和目标。"
+  },
+  "settings": {
+    "rate": "1 积分 = {{value}}",
+    "title": "单个积分的价值",
+    "description": "设置每个积分对应的金额",
+    "label": "单个积分的价值",
+    "example": "示例：{{points}} 积分 = {{amount}}"
+  },
+  "errors": {
+    "load": "无法加载零用钱。",
+    "action": "无法执行此操作。"
+  }
+}

--- a/client/src/i18n/locales/zh/server.json
+++ b/client/src/i18n/locales/zh/server.json
@@ -1,0 +1,19 @@
+{
+  "title": "连接到你的服务器",
+  "subtitle": "OpenFamily 是自托管应用，请将客户端连接到你自己的服务器。",
+  "urlLabel": "服务器地址",
+  "placeholder": "http://192.168.1.10:3001",
+  "hint": "使用你在浏览器中打开的同一地址（例如 http://192.168.1.10:3001），或使用 HTTPS / Tailscale 地址。",
+  "connect": "连接",
+  "connecting": "正在连接……",
+  "errors": {
+    "invalid": "请输入以 http:// 或 https:// 开头的有效 URL",
+    "unreachable": "无法连接此服务器，请检查地址以及服务器是否正在运行。"
+  },
+  "settings": {
+    "title": "服务器",
+    "connectedTo": "已连接到 {{url}}",
+    "change": "更换服务器",
+    "disconnect": "断开连接"
+  }
+}

--- a/client/src/i18n/locales/zh/settings.json
+++ b/client/src/i18n/locales/zh/settings.json
@@ -1,0 +1,91 @@
+{
+  "title": "设置",
+  "subtitle": "管理你的数据和偏好。",
+  "language": {
+    "title": "语言",
+    "subtitle": "选择应用界面的语言。"
+  },
+  "profile": {
+    "title": "头像",
+    "subtitle": "选择一张显示在应用菜单中的照片。",
+    "change": "更换照片",
+    "choose": "选择照片",
+    "remove": "移除"
+  },
+  "notif": {
+    "title": "推送通知",
+    "subtitle": "即使应用已关闭，也能直接在此设备上收到日程提醒。",
+    "unsupported": "此浏览器不支持通知。",
+    "denied": "权限被拒绝，请在浏览器设置中允许通知。",
+    "enable": "启用通知",
+    "disable": "停用通知",
+    "inProgress": "正在处理……",
+    "active": "已在此设备上启用通知。"
+  },
+  "currency": {
+    "title": "货币",
+    "subtitle": "选择应用中显示金额时使用的货币。"
+  },
+  "modules": {
+    "title": "模块",
+    "subtitle": "启用或隐藏可选模块，只保留你的家庭需要的功能。",
+    "parentOnly": "只有家长可以更改模块。",
+    "error": "更新模块时出错。",
+    "names": {
+      "kiosk": "信息屏模式",
+      "notes": "首页便签",
+      "ai": "AI 助手"
+    },
+    "descriptions": {
+      "budget": "跟踪家庭预算、支出和收入。",
+      "rewards": "管理孩子的零用钱和奖励。",
+      "meals": "规划每周餐食。",
+      "recipes": "家庭食谱簿。",
+      "planning": "每周安排（工作、上学、活动）。",
+      "integrations": "连接第三方服务（Mealie、Home Assistant 等）。",
+      "kiosk": "用于家庭共享屏幕的全屏显示。",
+      "notes": "显示在首页上的便签。",
+      "ai": "用于快速记录和整理的智能助手。"
+    }
+  },
+  "export": {
+    "title": "导出数据",
+    "subtitle": "将所有数据（预算、任务、食谱、成员、购物、日程、计划、餐食）下载为 JSON 文件。",
+    "button": "导出",
+    "inProgress": "正在导出……"
+  },
+  "import": {
+    "title": "导入数据",
+    "subtitle": "从 OpenFamily 导出文件恢复数据。现有数据不会被覆盖（重复项会跳过）。",
+    "success": "导入成功",
+    "itemsImported_one": "个项目已导入",
+    "itemsImported_other": "个项目已导入",
+    "chooseFile": "选择文件……",
+    "button": "导入",
+    "inProgress": "正在导入……",
+    "invalidJson": "JSON 文件无效。"
+  },
+  "entities": {
+    "family_members": "家庭成员",
+    "tasks": "任务",
+    "recipes": "食谱",
+    "meal_plans": "餐食计划",
+    "budget_entries": "预算记录",
+    "budget_limits": "预算限额",
+    "shopping_items": "购物项目",
+    "appointments": "日程",
+    "schedule_entries": "计划条目"
+  },
+  "errors": {
+    "notif": "配置通知时出错。",
+    "currency": "更新货币时出错。",
+    "avatarImage": "请选择图片。",
+    "avatarRead": "无法读取文件。",
+    "avatarInvalid": "图片无效。",
+    "avatarCanvas": "画布不可用。",
+    "avatarUpdate": "更新照片时出错。",
+    "avatarRemove": "移除照片时出错。",
+    "export": "导出时出错。",
+    "import": "导入时出错。"
+  }
+}

--- a/client/src/i18n/locales/zh/shopping.json
+++ b/client/src/i18n/locales/zh/shopping.json
@@ -1,0 +1,81 @@
+{
+  "loading": "正在加载购物清单……",
+  "header": {
+    "title": "购物清单",
+    "remaining_one": "还剩 {{count}} 个项目",
+    "remaining_other": "还剩 {{count}} 个项目"
+  },
+  "categories": {
+    "Alimentation": "食品杂货",
+    "Bebe": "婴儿用品",
+    "Menage": "家居用品",
+    "Sante": "健康",
+    "Autre": "其他"
+  },
+  "qty": "数量",
+  "storeMode": {
+    "enter": "商店模式",
+    "title": "商店模式",
+    "cart": "购物车中有 {{done}}/{{total}} 项",
+    "remaining_one": "还剩 {{count}} 项",
+    "remaining_other": "还剩 {{count}} 项",
+    "emptyList": "清单为空"
+  },
+  "add": {
+    "title": "添加项目",
+    "namePlaceholder": "例如：牛奶、面包",
+    "category": "类别",
+    "qtyPlaceholder": "1",
+    "pricePlaceholder": "2.50"
+  },
+  "templates": {
+    "title": "购物模板",
+    "newLabel": "新建模板",
+    "newPlaceholder": "例如：每周采购",
+    "create": "创建模板",
+    "existing": "现有模板",
+    "selectPlaceholder": "选择模板",
+    "optionItems_one": "{{count}} 个项目",
+    "optionItems_other": "{{count}} 个项目"
+  },
+  "list": {
+    "emptyTitle": "购物清单为空",
+    "emptySubtitle": "添加项目或应用模板。",
+    "completed_one": "已勾选项目（{{count}}）",
+    "completed_other": "已勾选项目（{{count}}）",
+    "clean": "清除"
+  },
+  "footer": {
+    "estimatedTotal": "预计总额"
+  },
+  "dialog": {
+    "title": "新建购物模板",
+    "description": "选择要包含在此模板中的项目",
+    "nameLabel": "模板名称",
+    "namePlaceholder": "例如：每周采购、水果蔬菜……",
+    "itemsSelected": "项目（已选择 {{selected}}/{{total}}）",
+    "selectAll": "全选",
+    "deselectAll": "取消全选",
+    "deselect": "取消选择",
+    "create": "创建模板"
+  },
+  "errors": {
+    "loadItems": "无法加载购物清单。",
+    "loadTemplates": "无法加载模板。",
+    "nameRequired": "必须填写项目名称。",
+    "quantityInvalid": "数量必须为正数。",
+    "priceInvalid": "价格必须为有效数字。",
+    "addFailed": "无法添加此项目。",
+    "toggleFailed": "无法更新此项目。",
+    "deleteFailed": "无法删除此项目。",
+    "clearFailed": "无法清除已勾选项目。",
+    "noItemsForTemplate": "清单中没有可用于创建模板的项目。",
+    "templateNameRequired": "请填写模板名称。",
+    "selectAtLeastOne": "请至少选择一个项目加入模板。",
+    "saveTemplateFailed": "无法保存模板。",
+    "selectTemplateApply": "请选择要应用的模板。",
+    "applyTemplateFailed": "无法应用此模板。",
+    "selectTemplateDelete": "请选择要删除的模板。",
+    "deleteTemplateFailed": "无法删除此模板。"
+  }
+}

--- a/client/src/i18n/locales/zh/tasks.json
+++ b/client/src/i18n/locales/zh/tasks.json
@@ -1,0 +1,74 @@
+{
+  "loading": "正在加载任务……",
+  "title": "任务",
+  "subtitle": "管理家庭任务并跟踪进度",
+  "newTask": "新建任务",
+  "priorities": {
+    "Haute": "高",
+    "Moyenne": "中",
+    "Basse": "低"
+  },
+  "frequencies": {
+    "Une fois": "一次",
+    "Quotidien": "每天",
+    "Hebdomadaire": "每周",
+    "Mensuel": "每月",
+    "Annuel": "每年"
+  },
+  "stats": {
+    "total": "总计",
+    "completed": "已完成",
+    "pending": "待完成",
+    "completionRate": "完成率"
+  },
+  "filters": {
+    "label": "筛选：",
+    "statusAll": "全部",
+    "statusPending": "待完成",
+    "statusCompleted": "已完成",
+    "allPriorities": "所有优先级",
+    "allMembers": "所有成员",
+    "unassigned": "未指派"
+  },
+  "empty": {
+    "none": "还没有任务，创建第一项任务吧！",
+    "noMatch": "没有符合所选筛选条件的任务。"
+  },
+  "due": "截止：{{date}}",
+  "dialog": {
+    "editTitle": "编辑任务",
+    "createTitle": "新建任务",
+    "description": "填写任务详情"
+  },
+  "form": {
+    "title": "标题",
+    "titlePlaceholder": "例如：采购食品",
+    "description": "说明（可选）",
+    "descriptionPlaceholder": "更多详情……",
+    "priority": "优先级",
+    "frequency": "频率",
+    "dueDate": "截止日期（可选）",
+    "assignTo": "指派给（可选）",
+    "noMembers": "没有可用成员",
+    "points": "可获得积分（可选）",
+    "pointsHint": "任务完成后，被指派的成员将获得这些积分。"
+  },
+  "approval": {
+    "pendingBadge": "等待批准",
+    "approve": "批准",
+    "reject": "拒绝",
+    "toastTitle": "做得好，任务已完成！",
+    "toastDescription": "家长批准后，你的积分就会到账。"
+  },
+  "confirmDelete": "确定要删除此任务吗？",
+  "errors": {
+    "loadTasks": "无法加载任务。",
+    "loadMembers": "无法加载成员。",
+    "loadStats": "无法加载统计数据。",
+    "saveTask": "无法保存此任务。",
+    "toggleTask": "无法更新此任务。",
+    "deleteTask": "无法删除此任务。",
+    "approveTask": "无法批准此任务。",
+    "rejectTask": "无法拒绝此任务。"
+  }
+}

--- a/server/src/lib/reminderScheduler.ts
+++ b/server/src/lib/reminderScheduler.ts
@@ -11,7 +11,7 @@ interface AppointmentRow {
     /** Naive local timestamp string ('YYYY-MM-DDTHH:mm:ss') — see the pg type parser in db.ts */
     start_time: string;
     location?: string;
-    /** Recipient's preferred language ('fr' | 'en'), defaults to 'fr' */
+    /** Recipient's preferred language ('fr' | 'en' | 'zh'), defaults to 'fr' */
     language: string;
 }
 
@@ -29,12 +29,18 @@ function buildTexts(appt: AppointmentRow, kind: '30min' | '1hour'): ReminderText
     // start_time is 'YYYY-MM-DDTHH:mm:ss' — extract HH:mm directly, no Date round-trip.
     const timeStr = appt.start_time.slice(11, 16);
     const suffix = `${timeStr}${appt.location ? ` · ${appt.location}` : ''}`;
-    const lang = appt.language === 'en' ? 'en' : 'fr';
+    const lang = appt.language === 'en' || appt.language === 'zh' ? appt.language : 'fr';
 
     if (lang === 'en') {
         return {
             title: `⏰ Reminder: ${appt.title}`,
             body: `${kind === '30min' ? 'In 30 minutes' : 'In 1 hour'} — ${suffix}`,
+        };
+    }
+    if (lang === 'zh') {
+        return {
+            title: `⏰ 提醒：${appt.title}`,
+            body: `${kind === '30min' ? '30 分钟后' : '1 小时后'} — ${suffix}`,
         };
     }
     return {

--- a/server/src/routes/userSettings.ts
+++ b/server/src/routes/userSettings.ts
@@ -4,7 +4,7 @@ import { authMiddleware, AuthRequest, requireParent } from '../middleware/auth';
 
 const router = Router();
 
-const SUPPORTED_LANGUAGES = ['fr', 'en'] as const;
+const SUPPORTED_LANGUAGES = ['fr', 'en', 'zh'] as const;
 
 // Single source of truth for the optional modules a family may hide.
 // Always-on modules (dashboard, shopping, tasks, calendar, family, settings)
@@ -38,13 +38,13 @@ export const parseDisabledModules = (raw: unknown): string[] => {
 
 // Update the authenticated user's preferred language (used for the UI and for
 // server-generated notifications such as appointment reminders).
-// PUT /api/auth/language — body: { "language": "fr" | "en" }
+// PUT /api/auth/language — body: { "language": "fr" | "en" | "zh" }
 router.put('/language', authMiddleware, async (req: AuthRequest, res) => {
     try {
         const { language } = req.body as { language?: unknown };
 
         if (typeof language !== 'string' || !SUPPORTED_LANGUAGES.includes(language as typeof SUPPORTED_LANGUAGES[number])) {
-            return res.status(400).json({ success: false, error: 'Invalid language. Supported values: fr, en' });
+            return res.status(400).json({ success: false, error: 'Invalid language. Supported values: fr, en, zh' });
         }
 
         // actualUserId: the preference belongs to the logged-in member, not the family owner.


### PR DESCRIPTION
## Summary

- Add complete Simplified Chinese translations across all 22 i18n namespaces
- Add config-driven language labels, ordering, and optional default currency rules
- Add zh-CN date and number formatting
- Add Chinese language persistence to the API and demo mode
- Add Simplified Chinese appointment reminder notifications
- Default accounts still using EUR to CNY when switching to Chinese, while preserving explicitly selected currencies

## Validation

- `npm run build`
- Verified locale JSON structure and interpolation placeholders
- Verified `zh-CN` runtime language resolution
- Verified CNY formatting with the `¥` symbol

## Notes

Language and currency remain independently configurable. The CNY rule only replaces the existing default EUR value and does not override another explicitly selected currency.