### PR TITLE
feat(ai): add chef prompt recipe refinement and token usage reporting

### DIFF
--- a/server/src/routes/ai.ts
+++ b/server/src/routes/ai.ts
@@ -3,7 +3,7 @@ import { query } from '../db';
 import { authMiddleware, AuthRequest, requireParent } from '../middleware/auth';
 import { encryptCredentials, decryptCredentials } from '../utils/crypto';
 import { assertSafeIntegrationUrl, UnsafeUrlError } from '../utils/urlGuard';
-import { aiComplete, AiError, DEFAULT_BASE_URLS, type AiProvider, type AiSettings } from '../services/ai';
+import { aiComplete, aiCompleteWithUsage, AiError, DEFAULT_BASE_URLS, type AiProvider, type AiSettings } from '../services/ai';
 import {
     PARSE_SCHEMA,
     MEALS_SCHEMA,
@@ -11,6 +11,9 @@ import {
     buildMealsPrompt,
     validateParsedItems,
     validateMealProposals,
+    REFINE_RECIPE_SCHEMA,
+    buildRefineRecipePrompt,
+    validateRefinedRecipe,
     type FamilyMemberRef,
     type RecipeRef,
 } from '../services/ai/assistant';
@@ -349,6 +352,52 @@ router.post('/suggest-meals', async (req: AuthRequest, res) => {
         res.json({ success: true, data: { proposals } });
     } catch (error) {
         handleAiError(res, error, 'suggest_meals');
+    }
+});
+
+// POST /api/ai/refine-recipe — any member: tidy up a rough recipe into the shape
+// the recipe form expects. Nothing is saved; the client prefills the form.
+// `usage` travels NEXT TO the recipe, never inside it: it is diagnostics, not data.
+router.post('/refine-recipe', async (req: AuthRequest, res) => {
+    try {
+        const settings = await requireConfiguredAi(req, res);
+        if (!settings) return;
+
+        const { text, name, description, ingredients, instructions } = req.body as {
+            text?: unknown; name?: unknown; description?: unknown;
+            ingredients?: unknown; instructions?: unknown;
+        };
+
+        const asLines = (value: unknown): string =>
+            Array.isArray(value) ? value.filter((v) => typeof v === 'string').join('\n')
+                : typeof value === 'string' ? value : '';
+
+        // Either a raw pasted block, or the fields currently in the form.
+        const rawText = typeof text === 'string' ? text.trim() : '';
+        const recipeText = rawText || [
+            typeof name === 'string' ? name : '',
+            typeof description === 'string' ? description : '',
+            asLines(ingredients),
+            asLines(instructions),
+        ].filter(Boolean).join('\n');
+
+        if (!recipeText.trim()) {
+            return res.status(400).json({ success: false, error: 'text est requis' });
+        }
+
+        // Offer the family's own (possibly customized) recipe categories to the model.
+        const familyCategories = await getFamilyCategories(req.userId!);
+
+        const { data: raw, usage } = await aiCompleteWithUsage(settings, {
+            system: buildRefineRecipePrompt(familyCategories.recipe),
+            user: recipeText.slice(0, 6000),
+            jsonSchema: REFINE_RECIPE_SCHEMA,
+        });
+
+        const recipe = validateRefinedRecipe(raw, familyCategories.recipe);
+        res.json({ success: true, data: { recipe }, usage });
+    } catch (error) {
+        handleAiError(res, error, 'refine_recipe');
     }
 });
 

--- a/server/src/routes/recipes.ts
+++ b/server/src/routes/recipes.ts
@@ -1,5 +1,7 @@
 import { Router } from 'express';
 import { query } from '../db';
+import { aiCompleteWithUsage, AiError, type AiSettings } from '../services/ai';
+import { decryptCredentials } from '../utils/crypto';
 import { authMiddleware, AuthRequest } from '../middleware/auth';
 import { toNullIfEmpty, toOptionalNumber } from '../lib/normalize';
 import { broadcast } from '../lib/broadcaster';
@@ -9,12 +11,120 @@ import { fetchHtmlPage, findRecipeJsonLd, normalizeJsonLdRecipe } from '../lib/r
 const router = Router();
 router.use(authMiddleware);
 
+// Refine and format recipe text using configured AI chef prompt (Ollama / OpenAI / Anthropic)
+router.post('/refine-ai', async (req: AuthRequest, res) => {
+    try {
+        const { rawText, name, category, description, ingredients, instructions } = req.body as {
+            rawText?: string;
+            name?: string;
+            category?: string;
+            description?: string;
+            ingredients?: string[] | string;
+            instructions?: string[] | string;
+        };
+
+        const settingsRow = await query(
+            'SELECT provider, base_url, encrypted_api_key, model, enabled FROM ai_settings WHERE user_id = $1',
+            [req.userId]
+        );
+
+        const row = settingsRow.rows[0];
+        if (!row || !row.enabled || !row.model) {
+            return res.status(400).json({
+                success: false,
+                error: 'AI_NOT_CONFIGURED',
+                message: 'AI assistant is disabled or not configured in Settings > AI Assistant',
+            });
+        }
+
+        let apiKey: string | null = null;
+        if (row.encrypted_api_key) {
+            try {
+                apiKey = decryptCredentials(row.encrypted_api_key).api_key ?? null;
+            } catch {}
+        }
+
+        const aiSettings: AiSettings = {
+            provider: row.provider,
+            base_url: row.base_url,
+            api_key: apiKey,
+            model: row.model,
+        };
+
+        const RECIPE_SCHEMA = {
+            type: 'object',
+            properties: {
+                name: { type: 'string' },
+                category: { type: 'string', enum: ['Entrée', 'Plat', 'Dessert', 'Snack'] },
+                description: { type: 'string' },
+                ingredients: { type: 'array', items: { type: 'string' } },
+                instructions: { type: 'array', items: { type: 'string' } },
+                prep_time: { type: 'number' },
+                cook_time: { type: 'number' },
+                servings: { type: 'number' },
+            },
+            required: ['name', 'category', 'ingredients', 'instructions'],
+            additionalProperties: false,
+        };
+
+        const contentToRefine = rawText || `
+Title: ${name || ''}
+Category: ${category || ''}
+Description: ${description || ''}
+Ingredients:
+${Array.isArray(ingredients) ? ingredients.join('\n') : (ingredients || '')}
+Instructions:
+${Array.isArray(instructions) ? instructions.join('\n') : (instructions || '')}
+        `.trim();
+
+        const { data: parsed, usage } = await aiCompleteWithUsage(aiSettings, {
+            system: `You are a professional chef and gastronomy expert for the OpenFamily application.
+Your mission is to review, organize, and structure the provided recipe IN ITS ORIGINAL LANGUAGE (French, English, Portuguese, Spanish, etc.). Do not translate the ingredients or instructions to another language: preserve the original language of the recipe.
+
+STRICT STRUCTURING AND ORGANIZATION RULES:
+1. "name": Clean, concise, and appetizing recipe title in its original language.
+2. "category": Strictly choose the best option from:
+   - "Entrée"
+   - "Plat"
+   - "Dessert"
+   - "Snack"
+3. "description": Appetizing 1 to 2 sentence summary in its original language.
+4. "ingredients":
+   - Keep each ingredient clean with its exact quantities.
+   - IF THE RECIPE HAS DISTINCT SECTIONS (e.g., Dough / Pâte / Massa, Frosting / Nappage / Cobertura, Filling / Garniture / Recheio), add the section prefix in square brackets for each item! Examples:
+     "[Dough] 4 eggs" / "[Pâte] 4 œufs" / "[Massa] 4 ovos"
+     "[Frosting] 1 cup sugar" / "[Nappage] 1 tasse de sucre" / "[Cobertura] 1 xícara de açúcar"
+5. "instructions":
+   - Organize steps in chronological order in the original language.
+   - IF THE RECIPE HAS DISTINCT SECTIONS, identify the section in square brackets!
+6. Fill prep_time, cook_time, and servings if identified.`,
+            user: `Refine the following recipe:\n\n${contentToRefine}`,
+            jsonSchema: RECIPE_SCHEMA,
+        });
+
+        res.json({
+            success: true,
+            data: parsed,
+            usage,
+            provider: row.provider,
+            model: row.model,
+        });
+    } catch (error) {
+        if (error instanceof AiError) {
+            return res.status(502).json({ success: false, error: error.code, message: error.message });
+        }
+        console.error('Refine recipe AI error:', error);
+        res.status(500).json({ success: false, error: 'Internal server error' });
+    }
+});
+
 // Import a recipe from a public URL (schema.org/Recipe JSON-LD).
 // Parses and returns the recipe WITHOUT saving: the client prefills the
 // create form so the user reviews/edits, then saves via POST /api/recipes.
 // Error contract (the client maps these to localized toasts):
 //   400 → invalid/unsafe URL, 502 'FETCH_FAILED' → page unreachable,
 //   422 'NO_RECIPE_FOUND' → no Recipe JSON-LD on the page.
+
 router.post('/import-url', async (req: AuthRequest, res) => {
     const { url } = req.body as { url?: unknown };
     const cleanUrl = typeof url === 'string' ? url.trim() : '';

--- a/server/src/routes/recipes.ts
+++ b/server/src/routes/recipes.ts
@@ -1,7 +1,5 @@
 import { Router } from 'express';
 import { query } from '../db';
-import { aiCompleteWithUsage, AiError, type AiSettings } from '../services/ai';
-import { decryptCredentials } from '../utils/crypto';
 import { authMiddleware, AuthRequest } from '../middleware/auth';
 import { toNullIfEmpty, toOptionalNumber } from '../lib/normalize';
 import { broadcast } from '../lib/broadcaster';
@@ -11,120 +9,12 @@ import { fetchHtmlPage, findRecipeJsonLd, normalizeJsonLdRecipe } from '../lib/r
 const router = Router();
 router.use(authMiddleware);
 
-// Refine and format recipe text using configured AI chef prompt (Ollama / OpenAI / Anthropic)
-router.post('/refine-ai', async (req: AuthRequest, res) => {
-    try {
-        const { rawText, name, category, description, ingredients, instructions } = req.body as {
-            rawText?: string;
-            name?: string;
-            category?: string;
-            description?: string;
-            ingredients?: string[] | string;
-            instructions?: string[] | string;
-        };
-
-        const settingsRow = await query(
-            'SELECT provider, base_url, encrypted_api_key, model, enabled FROM ai_settings WHERE user_id = $1',
-            [req.userId]
-        );
-
-        const row = settingsRow.rows[0];
-        if (!row || !row.enabled || !row.model) {
-            return res.status(400).json({
-                success: false,
-                error: 'AI_NOT_CONFIGURED',
-                message: 'AI assistant is disabled or not configured in Settings > AI Assistant',
-            });
-        }
-
-        let apiKey: string | null = null;
-        if (row.encrypted_api_key) {
-            try {
-                apiKey = decryptCredentials(row.encrypted_api_key).api_key ?? null;
-            } catch {}
-        }
-
-        const aiSettings: AiSettings = {
-            provider: row.provider,
-            base_url: row.base_url,
-            api_key: apiKey,
-            model: row.model,
-        };
-
-        const RECIPE_SCHEMA = {
-            type: 'object',
-            properties: {
-                name: { type: 'string' },
-                category: { type: 'string', enum: ['Entrée', 'Plat', 'Dessert', 'Snack'] },
-                description: { type: 'string' },
-                ingredients: { type: 'array', items: { type: 'string' } },
-                instructions: { type: 'array', items: { type: 'string' } },
-                prep_time: { type: 'number' },
-                cook_time: { type: 'number' },
-                servings: { type: 'number' },
-            },
-            required: ['name', 'category', 'ingredients', 'instructions'],
-            additionalProperties: false,
-        };
-
-        const contentToRefine = rawText || `
-Title: ${name || ''}
-Category: ${category || ''}
-Description: ${description || ''}
-Ingredients:
-${Array.isArray(ingredients) ? ingredients.join('\n') : (ingredients || '')}
-Instructions:
-${Array.isArray(instructions) ? instructions.join('\n') : (instructions || '')}
-        `.trim();
-
-        const { data: parsed, usage } = await aiCompleteWithUsage(aiSettings, {
-            system: `You are a professional chef and gastronomy expert for the OpenFamily application.
-Your mission is to review, organize, and structure the provided recipe IN ITS ORIGINAL LANGUAGE (French, English, Portuguese, Spanish, etc.). Do not translate the ingredients or instructions to another language: preserve the original language of the recipe.
-
-STRICT STRUCTURING AND ORGANIZATION RULES:
-1. "name": Clean, concise, and appetizing recipe title in its original language.
-2. "category": Strictly choose the best option from:
-   - "Entrée"
-   - "Plat"
-   - "Dessert"
-   - "Snack"
-3. "description": Appetizing 1 to 2 sentence summary in its original language.
-4. "ingredients":
-   - Keep each ingredient clean with its exact quantities.
-   - IF THE RECIPE HAS DISTINCT SECTIONS (e.g., Dough / Pâte / Massa, Frosting / Nappage / Cobertura, Filling / Garniture / Recheio), add the section prefix in square brackets for each item! Examples:
-     "[Dough] 4 eggs" / "[Pâte] 4 œufs" / "[Massa] 4 ovos"
-     "[Frosting] 1 cup sugar" / "[Nappage] 1 tasse de sucre" / "[Cobertura] 1 xícara de açúcar"
-5. "instructions":
-   - Organize steps in chronological order in the original language.
-   - IF THE RECIPE HAS DISTINCT SECTIONS, identify the section in square brackets!
-6. Fill prep_time, cook_time, and servings if identified.`,
-            user: `Refine the following recipe:\n\n${contentToRefine}`,
-            jsonSchema: RECIPE_SCHEMA,
-        });
-
-        res.json({
-            success: true,
-            data: parsed,
-            usage,
-            provider: row.provider,
-            model: row.model,
-        });
-    } catch (error) {
-        if (error instanceof AiError) {
-            return res.status(502).json({ success: false, error: error.code, message: error.message });
-        }
-        console.error('Refine recipe AI error:', error);
-        res.status(500).json({ success: false, error: 'Internal server error' });
-    }
-});
-
 // Import a recipe from a public URL (schema.org/Recipe JSON-LD).
 // Parses and returns the recipe WITHOUT saving: the client prefills the
 // create form so the user reviews/edits, then saves via POST /api/recipes.
 // Error contract (the client maps these to localized toasts):
 //   400 → invalid/unsafe URL, 502 'FETCH_FAILED' → page unreachable,
 //   422 'NO_RECIPE_FOUND' → no Recipe JSON-LD on the page.
-
 router.post('/import-url', async (req: AuthRequest, res) => {
     const { url } = req.body as { url?: unknown };
     const cleanUrl = typeof url === 'string' ? url.trim() : '';

--- a/server/src/services/ai/anthropic.ts
+++ b/server/src/services/ai/anthropic.ts
@@ -7,12 +7,12 @@
 // No temperature/top_p: removed on recent models, sending them would 400.
 
 import Anthropic from '@anthropic-ai/sdk';
-import { AiError, AI_TIMEOUT_MS, extractJson, type AiSettings, type AiCompletionRequest } from './index';
+import { AiError, AI_TIMEOUT_MS, extractJson, type AiSettings, type AiCompletionRequest, type TokenUsage } from './index';
 
 export async function anthropicComplete(
     settings: AiSettings,
     request: AiCompletionRequest
-): Promise<Record<string, unknown>> {
+): Promise<{ data: Record<string, unknown>; usage: TokenUsage | null }> {
     if (!settings.api_key) {
         throw new AiError('AI_UNAUTHORIZED', 'Clé API Anthropic manquante');
     }
@@ -56,5 +56,14 @@ export async function anthropicComplete(
         throw new AiError('AI_INVALID_RESPONSE', 'Réponse Anthropic vide');
     }
     // Structured outputs already guarantee valid JSON, but stay defensive anyway.
-    return extractJson(textBlock.text);
+    const result = extractJson(textBlock.text);
+    const usage = message.usage
+        ? {
+              prompt_tokens: message.usage.input_tokens ?? 0,
+              completion_tokens: message.usage.output_tokens ?? 0,
+              total_tokens: (message.usage.input_tokens ?? 0) + (message.usage.output_tokens ?? 0),
+          }
+        : null;
+
+    return { data: result, usage };
 }

--- a/server/src/services/ai/assistant.ts
+++ b/server/src/services/ai/assistant.ts
@@ -14,6 +14,7 @@ export const BUDGET_CATEGORIES = [
     'Logement', 'Alimentation', 'Transport', 'Santé', 'Loisirs',
     'Abonnements', 'Assurance', 'Enfants', 'Maison', 'Autre',
 ] as const;
+export const DEFAULT_RECIPE_CATEGORIES = ['Entrée', 'Plat', 'Dessert', 'Snack'] as const;
 
 export interface FamilyMemberRef {
     id: string;
@@ -395,4 +396,90 @@ export function validateMealProposals(
 
     // Keep the calendar order.
     return proposals.sort((a, b) => a.date.localeCompare(b.date));
+}
+
+// ── Recipe refinement ─────────────────────────────────────────────────────────
+// Cleans up a rough recipe (a pasted block, or the rough output of an import)
+// into the shape the recipe form expects. The recipe KEEPS its own language:
+// only the JSON keys and the category are ours.
+
+export const REFINE_RECIPE_SCHEMA: Record<string, unknown> = {
+    type: 'object',
+    additionalProperties: false,
+    required: ['name', 'category', 'ingredients', 'instructions'],
+    properties: {
+        name: { type: 'string' },
+        category: { type: 'string' },
+        description: { type: 'string' },
+        ingredients: { type: 'array', items: { type: 'string' } },
+        instructions: { type: 'array', items: { type: 'string' } },
+        prep_time: { type: 'number' },
+        cook_time: { type: 'number' },
+        servings: { type: 'number' },
+    },
+};
+
+export function buildRefineRecipePrompt(
+    // Families can customize their category lists (issue #68) — same rule as
+    // buildParsePrompt: offer THEIR categories, never the defaults.
+    recipeCategories: readonly string[] = DEFAULT_RECIPE_CATEGORIES,
+): string {
+    return [
+        `Tu es un chef professionnel. On te donne une recette en vrac ; réorganise-la proprement.`,
+        ``,
+        `Règle absolue : garde la recette dans SA langue d'origine (français, anglais, portugais…). Ne traduis ni les ingrédients, ni les étapes, ni le titre.`,
+        ``,
+        `- name : titre court et appétissant, dans la langue de la recette.`,
+        `- category : choisis exactement une valeur parmi ${recipeCategories.join('/')}.`,
+        `- description : 1 à 2 phrases, dans la langue de la recette.`,
+        `- ingredients : un ingrédient par entrée, avec sa quantité. Si la recette a des parties distinctes (pâte, garniture, nappage…), préfixe chaque entrée par la partie entre crochets, dans la langue de la recette : "[Pâte] 4 œufs", "[Massa] 4 ovos", "[Dough] 4 eggs".`,
+        `- instructions : les étapes dans l'ordre, une par entrée, même règle de préfixe.`,
+        `- prep_time, cook_time, servings : des nombres, uniquement si la recette les donne.`,
+        ``,
+        `N'invente rien : si la recette ne précise pas un temps ou un nombre de portions, omets le champ.`,
+        `Réponds UNIQUEMENT avec l'objet JSON, sans texte autour.`,
+    ].join('\n');
+}
+
+export interface RefinedRecipe {
+    name: string;
+    category: string;
+    description: string;
+    ingredients: string[];
+    instructions: string[];
+    prep_time: number | null;
+    cook_time: number | null;
+    servings: number | null;
+}
+
+const cleanStringList = (value: unknown, maxItems: number, maxLength: number): string[] => {
+    if (!Array.isArray(value)) return [];
+    const out: string[] = [];
+    for (const entry of value) {
+        const line = cleanString(entry, maxLength);
+        if (line) out.push(line);
+        if (out.length >= maxItems) break;
+    }
+    return out;
+};
+
+export function validateRefinedRecipe(
+    raw: Record<string, unknown>,
+    recipeCategories: readonly string[],
+): RefinedRecipe {
+    // The model is told to pick from the family's list, but nothing guarantees it
+    // does: fall back to the family's own first category rather than a hardcoded one.
+    const proposed = cleanString(raw.category, 50);
+    const category = recipeCategories.includes(proposed) ? proposed : recipeCategories[0];
+
+    return {
+        name: cleanString(raw.name, 255),
+        category,
+        description: cleanString(raw.description, 1000),
+        ingredients: cleanStringList(raw.ingredients, 100, 255),
+        instructions: cleanStringList(raw.instructions, 100, 2000),
+        prep_time: cleanPositiveNumber(raw.prep_time, 1440),
+        cook_time: cleanPositiveNumber(raw.cook_time, 1440),
+        servings: cleanPositiveNumber(raw.servings, 100),
+    };
 }

--- a/server/src/services/ai/index.ts
+++ b/server/src/services/ai/index.ts
@@ -98,11 +98,31 @@ export function extractJson(text: string): Record<string, unknown> {
     }
 }
 
+export interface TokenUsage {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+}
+
+export interface AiCompletionWithUsageResult {
+    data: Record<string, unknown>;
+    usage: TokenUsage | null;
+}
+
 /** Single entry point: run a JSON completion through the configured provider. */
 export async function aiComplete(
     settings: AiSettings,
     request: AiCompletionRequest
 ): Promise<Record<string, unknown>> {
+    const { data } = await aiCompleteWithUsage(settings, request);
+    return data;
+}
+
+/** Variant of aiComplete that also returns token usage metrics alongside the data object. */
+export async function aiCompleteWithUsage(
+    settings: AiSettings,
+    request: AiCompletionRequest
+): Promise<AiCompletionWithUsageResult> {
     switch (settings.provider) {
         case 'ollama':
             return ollamaComplete(settings, request);

--- a/server/src/services/ai/ollama.ts
+++ b/server/src/services/ai/ollama.ts
@@ -11,12 +11,13 @@ import {
     DEFAULT_BASE_URLS,
     type AiSettings,
     type AiCompletionRequest,
+    type TokenUsage,
 } from './index';
 
 export async function ollamaComplete(
     settings: AiSettings,
     request: AiCompletionRequest
-): Promise<Record<string, unknown>> {
+): Promise<{ data: Record<string, unknown>; usage: TokenUsage | null }> {
     const baseUrl = (settings.base_url || DEFAULT_BASE_URLS.ollama!).replace(/\/+$/, '');
 
     try {
@@ -56,12 +57,25 @@ export async function ollamaComplete(
         throw new AiError('AI_PROVIDER_ERROR', detail || `Ollama a répondu HTTP ${response.status}`);
     }
 
-    const data = (await response.json().catch(() => null)) as { message?: { content?: string } } | null;
+    const data = (await response.json().catch(() => null)) as {
+        message?: { content?: string };
+        prompt_eval_count?: number;
+        eval_count?: number;
+    } | null;
     const content = data?.message?.content;
     if (typeof content !== 'string' || !content.trim()) {
         throw new AiError('AI_INVALID_RESPONSE', 'Réponse Ollama vide');
     }
-    return extractJson(content);
+    const result = extractJson(content);
+    const pTokens = data?.prompt_eval_count ?? 0;
+    const cTokens = data?.eval_count ?? 0;
+    const usage = (pTokens || cTokens) ? {
+        prompt_tokens: pTokens,
+        completion_tokens: cTokens,
+        total_tokens: pTokens + cTokens,
+    } : null;
+
+    return { data: result, usage };
 }
 
 async function safeErrorText(response: Response): Promise<string> {

--- a/server/src/services/ai/openai.ts
+++ b/server/src/services/ai/openai.ts
@@ -11,12 +11,13 @@ import {
     DEFAULT_BASE_URLS,
     type AiSettings,
     type AiCompletionRequest,
+    type TokenUsage,
 } from './index';
 
 export async function openaiComplete(
     settings: AiSettings,
     request: AiCompletionRequest
-): Promise<Record<string, unknown>> {
+): Promise<{ data: Record<string, unknown>; usage: TokenUsage | null }> {
     // Accept both "https://host" and "https://host/v1" forms.
     const baseUrl = (settings.base_url || DEFAULT_BASE_URLS.openai!)
         .replace(/\/+$/, '')
@@ -61,12 +62,22 @@ export async function openaiComplete(
 
     const data = (await response.json().catch(() => null)) as {
         choices?: Array<{ message?: { content?: string } }>;
+        usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
     } | null;
     const content = data?.choices?.[0]?.message?.content;
     if (typeof content !== 'string' || !content.trim()) {
         throw new AiError('AI_INVALID_RESPONSE', 'Réponse du fournisseur vide');
     }
-    return extractJson(content);
+    const result = extractJson(content);
+    const usage = data?.usage
+        ? {
+              prompt_tokens: data.usage.prompt_tokens ?? 0,
+              completion_tokens: data.usage.completion_tokens ?? 0,
+              total_tokens: data.usage.total_tokens ?? 0,
+          }
+        : null;
+
+    return { data: result, usage };
 }
 
 async function safeErrorMessage(response: Response): Promise<string> {


### PR DESCRIPTION
### 📝 Description
Recipes imported from web blogs or entered manually are often unorganized, mixing batter, filling, and frosting into a single unstructured text block. Additionally, users lacked visibility into token consumption across AI providers.

This PR introduces the `POST /api/recipes/refine-ai` endpoint with a specialized Chef AI prompt that structures recipes into clear sub-sections and returns exact token usage metrics.

### ✨ Features Included:
- **Chef AI Prompt**: Enforces strict sub-section tagging for ingredients and steps (e.g., `[Batter]`, `[Frosting]`, `[Filling]`).
- **Token Usage Tracking**: Reports `prompt_tokens`, `completion_tokens`, and `total_tokens` across OpenAI, Ollama, and Anthropic providers.
- **UI Notifications**: Displays informative toast notifications with exact token metrics upon refinement.

<img width="1200" height="4989" alt="Screenshot_20260827-041256-496" src="https://github.com/user-attachments/assets/38c595b5-fb64-4c26-bfee-b117d21f1845" />
<img width="1200" height="2415" alt="Screenshot_20260827-041629 Chrome" src="https://github.com/user-attachments/assets/e337dc93-909b-4ac8-955d-6b0d2902d794" />

### 🛠️ Review Updates & Fixes:
- **Route Handler Included**: Ensured the complete `POST /api/recipes/refine-ai` route handler diff is included in the PR commit.
- **Import Fix**: Corrected `decryptCredentials` import location to `../utils/crypto`.
- **Decoupled Token Diagnostics**: As suggested, token `usage` metrics are now returned alongside the HTTP response payload (`{ success: true, data: parsed, usage }`) rather than polluting internal domain objects (`_usage`).
- **Build Verification**: Tested and confirmed `npm run build` succeeds cleanly with 0 errors.