### PR TITLE
feat(calendar): all-day appointments

### DIFF
--- a/client/src/i18n/locales/en/calendar.json
+++ b/client/src/i18n/locales/en/calendar.json
@@ -46,7 +46,8 @@
     "repeatDays": "day(s)",
     "repeatWeeks": "week(s)",
     "repeatMonths": "month(s)",
-    "repeatYears": "year(s)"
+    "repeatYears": "year(s)",
+    "allDay": "All day"
   },
   "feed": {
     "title": "Export calendar (iCal)",

--- a/client/src/i18n/locales/fr/calendar.json
+++ b/client/src/i18n/locales/fr/calendar.json
@@ -46,7 +46,8 @@
     "repeatDays": "jour(s)",
     "repeatWeeks": "semaine(s)",
     "repeatMonths": "mois",
-    "repeatYears": "an(s)"
+    "repeatYears": "an(s)",
+    "allDay": "Toute la journée"
   },
   "feed": {
     "title": "Exporter le calendrier (iCal)",

--- a/client/src/i18n/locales/pt/calendar.json
+++ b/client/src/i18n/locales/pt/calendar.json
@@ -46,7 +46,8 @@
     "repeatDays": "dia(s)",
     "repeatWeeks": "semana(s)",
     "repeatMonths": "mês(es)",
-    "repeatYears": "ano(s)"
+    "repeatYears": "ano(s)",
+    "allDay": "Dia inteiro"
   },
   "feed": {
     "title": "Exportar calendário (iCal / Google)",

--- a/client/src/i18n/locales/ru/calendar.json
+++ b/client/src/i18n/locales/ru/calendar.json
@@ -46,7 +46,8 @@
     "repeatDays": "дн.",
     "repeatWeeks": "нед.",
     "repeatMonths": "мес.",
-    "repeatYears": "г."
+    "repeatYears": "г.",
+    "allDay": "Весь день"
   },
   "feed": {
     "title": "Экспорт календаря (iCal)",

--- a/client/src/i18n/locales/zh/calendar.json
+++ b/client/src/i18n/locales/zh/calendar.json
@@ -46,7 +46,8 @@
     "repeatDays": "天",
     "repeatWeeks": "周",
     "repeatMonths": "个月",
-    "repeatYears": "年"
+    "repeatYears": "年",
+    "allDay": "全天"
   },
   "feed": {
     "title": "导出日历（iCal）",

--- a/client/src/pages/Calendar.tsx
+++ b/client/src/pages/Calendar.tsx
@@ -31,6 +31,7 @@ interface Appointment {
     reminder_1hour: boolean;
     notes?: string;
     color?: string;
+    is_all_day?: boolean;
 }
 
 interface FamilyMember {
@@ -169,6 +170,7 @@ const Calendar: React.FC = () => {
         reminder_1hour: false,
         notes: '',
         color: '#DC4A60',
+        is_all_day: false,
         recurrence_frequency: 'none' as 'none' | 'daily' | 'weekly' | 'monthly' | 'yearly',
         recurrence_interval: 1,
         recurrence_until: '',
@@ -294,10 +296,29 @@ const Calendar: React.FC = () => {
             return;
         }
 
-        if (formData.end_time && new Date(formData.end_time).getTime() < new Date(formData.start_time).getTime()) {
+        if (
+            !formData.is_all_day
+            && formData.end_time
+            && new Date(formData.end_time).getTime() < new Date(formData.start_time).getTime()
+        ) {
             setError(t('calendar:errors.endAfterStart'));
             return;
         }
+
+        // An all-day appointment still stores real times, spanning the day it
+        // starts on, so every existing query and the agenda views keep working.
+        // Its reminders are cleared: "30 minutes before" means nothing without a
+        // start time the user chose.
+        const day = formData.start_time.slice(0, 10);
+        const payload = formData.is_all_day
+            ? {
+                ...formData,
+                start_time: `${day}T00:00`,
+                end_time: `${day}T23:59`,
+                reminder_30min: false,
+                reminder_1hour: false,
+            }
+            : formData;
 
         try {
             if (
@@ -307,7 +328,7 @@ const Calendar: React.FC = () => {
                 setRecurrenceScopeAction({
                     mode: 'edit',
                     appointment: editingAppointment,
-                    payload: { ...formData },
+                    payload: { ...payload },
                     returnToEditor: true,
                 });
                 setDialogOpen(false);
@@ -315,9 +336,9 @@ const Calendar: React.FC = () => {
             }
 
             if (editingAppointment) {
-                await api.put(`/api/appointments/${editingAppointment.id}`, formData);
+                await api.put(`/api/appointments/${editingAppointment.id}`, payload);
             } else {
-                await api.post('/api/appointments', formData);
+                await api.post('/api/appointments', payload);
             }
 
             setDialogOpen(false);
@@ -454,6 +475,7 @@ const Calendar: React.FC = () => {
             reminder_1hour: appointment.reminder_1hour,
             notes: appointment.notes || '',
             color: appointment.color || '#DC4A60',
+            is_all_day: Boolean(appointment.is_all_day),
             recurrence_frequency: appointment.recurrence_frequency || 'none',
             recurrence_interval: appointment.recurrence_interval || 1,
             recurrence_until: appointment.recurrence_until
@@ -502,6 +524,7 @@ const Calendar: React.FC = () => {
             reminder_1hour: false,
             notes: '',
             color: '#DC4A60',
+            is_all_day: false,
             recurrence_frequency: 'none',
             recurrence_interval: 1,
             recurrence_until: '',
@@ -960,33 +983,50 @@ const Calendar: React.FC = () => {
                         </div>
                     </div>
                     <div className="rounded-input border border-border bg-surface-2/40 p-3">
-                        <p className="mb-3 text-caption font-medium text-foreground">{t('calendar:form.scheduling')}</p>
+                        <div className="mb-3 flex items-center justify-between gap-3">
+                            <p className="text-caption font-medium text-foreground">{t('calendar:form.scheduling')}</p>
+                            <label className="flex cursor-pointer items-center gap-2 text-caption text-foreground">
+                                <input
+                                    type="checkbox"
+                                    className="h-4 w-4 rounded border-input"
+                                    checked={formData.is_all_day}
+                                    onChange={(e) => setFormData({ ...formData, is_all_day: e.target.checked })}
+                                />
+                                {t('calendar:form.allDay')}
+                            </label>
+                        </div>
                         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                             <DatePicker
                                 label={t('calendar:form.startDate')}
                                 value={selectedDate}
                                 onChange={handleDateChange}
                             />
-                            <Input
-                                label={t('calendar:form.startTime')}
-                                type="time"
-                                value={selectedStartTime}
-                                onChange={(e) => handleStartTimeChange(e.target.value)}
-                                required
-                            />
-                            <DatePicker
-                                label={t('calendar:form.endDate')}
-                                value={selectedEndDate}
-                                onChange={handleEndDateChange}
-                            />
-                            <Input
-                                label={t('calendar:form.endTime')}
-                                type="time"
-                                value={selectedEndTime}
-                                onChange={(e) => handleEndTimeChange(e.target.value)}
-                            />
+                            {/* An all-day appointment spans its whole day, so the times are
+                                computed on submit and there is nothing to ask for here. */}
+                            {!formData.is_all_day && (
+                                <>
+                                    <Input
+                                        label={t('calendar:form.startTime')}
+                                        type="time"
+                                        value={selectedStartTime}
+                                        onChange={(e) => handleStartTimeChange(e.target.value)}
+                                        required
+                                    />
+                                    <DatePicker
+                                        label={t('calendar:form.endDate')}
+                                        value={selectedEndDate}
+                                        onChange={handleEndDateChange}
+                                    />
+                                    <Input
+                                        label={t('calendar:form.endTime')}
+                                        type="time"
+                                        value={selectedEndTime}
+                                        onChange={(e) => handleEndTimeChange(e.target.value)}
+                                    />
+                                </>
+                            )}
                         </div>
-                        <div className="mt-3 flex flex-wrap gap-2">
+                        <div className={`mt-3 flex-wrap gap-2 ${formData.is_all_day ? 'hidden' : 'flex'}`}>
                             <Button type="button" variant="ghost" size="sm" onClick={() => applyDurationPreset(30)}>
                                 +30 min
                             </Button>
@@ -1126,7 +1166,9 @@ const Calendar: React.FC = () => {
                             </div>
                         )}
                     </div>
-                    <div className="space-y-2">
+                    {/* Reminders are relative to a start time the user picked, so they
+                        have nothing to count down from on an all-day appointment. */}
+                    <div className={`space-y-2 ${formData.is_all_day ? 'hidden' : ''}`}>
                         <label className="block text-label font-medium text-foreground">{t('calendar:form.reminders')}</label>
                         <div className="flex items-center gap-4">
                             <label className="flex items-center gap-2 cursor-pointer">

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -375,6 +375,11 @@ export const runMigrations = async () => {
         'CREATE INDEX IF NOT EXISTS idx_appointment_recurrence_exceptions_appointment ON appointment_recurrence_exceptions(appointment_id)',
         // Migration 024: shared color for calendar appointments.
         "ALTER TABLE appointments ADD COLUMN IF NOT EXISTS color VARCHAR(7) NOT NULL DEFAULT '#DC4A60'",
+        // Migration 025: an appointment can cover a whole day rather than a time
+        // slot. The times are still stored, spanning 00:00 to 23:59, so every
+        // existing query keeps working; the flag only says how to show it and
+        // silences the reminders, which mean nothing without a start time.
+        'ALTER TABLE appointments ADD COLUMN IF NOT EXISTS is_all_day BOOLEAN NOT NULL DEFAULT false',
     ];
 
     for (const migration of migrations) {

--- a/server/src/routes/appointments.ts
+++ b/server/src/routes/appointments.ts
@@ -470,6 +470,7 @@ router.post('/', async (req: AuthRequest, res) => {
             recurrence_interval,
             recurrence_until,
             color,
+            is_all_day,
         } = req.body;
 
         const cleanedTitle = typeof title === 'string' ? title.trim() : '';
@@ -505,11 +506,12 @@ router.post('/', async (req: AuthRequest, res) => {
             `INSERT INTO appointments (
                 user_id, title, description, start_time, end_time, location,
                 family_member_ids, reminder_30min, reminder_1hour, notes,
-                recurrence_frequency, recurrence_interval, recurrence_until, color
+                recurrence_frequency, recurrence_interval, recurrence_until, color,
+                is_all_day
             )
             VALUES (
                 $1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, $10,
-                $11, $12, $13, $14
+                $11, $12, $13, $14, $15
             ) RETURNING *`,
             [
                 req.userId,
@@ -526,6 +528,7 @@ router.post('/', async (req: AuthRequest, res) => {
                 recurrenceInterval,
                 recurrenceUntil,
                 normalizeAppointmentColor(color),
+                Boolean(is_all_day),
             ]
         );
 
@@ -560,6 +563,7 @@ router.put('/:id', async (req: AuthRequest, res) => {
             recurrence_interval,
             recurrence_until,
             color,
+            is_all_day,
         } = req.body;
 
         const updates: string[] = [];
@@ -617,6 +621,10 @@ router.put('/:id', async (req: AuthRequest, res) => {
 
         if (notes !== undefined) {
             pushUpdate('notes', toNullIfEmpty(notes));
+        }
+
+        if (is_all_day !== undefined) {
+            pushUpdate('is_all_day', Boolean(is_all_day));
         }
 
         if (color !== undefined) {
@@ -710,6 +718,7 @@ router.put('/:id/occurrences/:date', async (req: AuthRequest, res) => {
             'reminder_1hour',
             'notes',
             'color',
+            'is_all_day',
         ];
 
         const overrideData: Record<string, any> = {};


### PR DESCRIPTION
Second slice from the community enhancement set in #85, kept deliberately small: one migration, one flag, one checkbox.

## What it does

An appointment can cover a whole day instead of a time slot.

The times are still stored, spanning 00:00 to 23:59 of the day it starts on, so the month view, the agenda, the iCal feed and every existing query keep working without knowing about the flag. It only changes how the form behaves and what is shown.

Ticking the box hides the time fields and the duration presets, since they are computed, and hides the reminders: "30 minutes before" has nothing to count down from when nobody chose a start time. Both reminders are cleared on save rather than left set and ignored, so what is stored matches what the form says.

## Verification

Against a live database, 15 checks, all passing:

- the flag persists on create and comes back through the listing
- the stored times really span the day
- a normal appointment still defaults to `false`
- the update endpoint toggles it on and off
- a **partial** update does not silently reset it
- an all-day appointment can **recur**, and every expanded occurrence keeps the flag
- another account cannot change it

## Scope

Everything else in that patch stays out for now, each being its own decision: budget recurrence, the budget to calendar link, and moving Kakeibo to a third tab.