### PR TITLE
fix(docker): wire REGISTRATION_ENABLED through Docker Compose

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -27,6 +27,10 @@ ARG VITE_API_URL=
 ARG VITE_WS_URL=
 ENV VITE_API_URL=$VITE_API_URL
 ENV VITE_WS_URL=$VITE_WS_URL
+# Set to false to hide the "Sign up" link once the family is set up. Read at build
+# time by Vite, so changing it requires rebuilding the image.
+ARG VITE_REGISTRATION_ENABLED=true
+ENV VITE_REGISTRATION_ENABLED=$VITE_REGISTRATION_ENABLED
 RUN cd client && npm run build
 
 # Production stage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       VAPID_PRIVATE_KEY: ${VAPID_PRIVATE_KEY}
       VAPID_SUBJECT: ${VAPID_SUBJECT}
       CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:3000}
+      REGISTRATION_ENABLED: ${REGISTRATION_ENABLED:-true}
     ports:
       - "3001:3001"
     depends_on:
@@ -60,6 +61,9 @@ services:
         # works from any device. Set these only to serve the API from a separate origin.
         VITE_API_URL: ${VITE_API_URL:-}
         VITE_WS_URL: ${VITE_WS_URL:-}
+        # Same flag as the server's REGISTRATION_ENABLED: hides the "Sign up"
+        # link so the UI matches what the API accepts.
+        VITE_REGISTRATION_ENABLED: ${REGISTRATION_ENABLED:-true}
     container_name: openfamily-client
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Problem

`REGISTRATION_ENABLED` is documented in `.env.example` and honoured by the code:

- `server/src/routes/auth.ts:38` returns 403 on `/api/auth/register`
- `client/src/pages/Login.tsx:17` hides the "Sign up" link

But `docker-compose.yml` never passes it anywhere. Setting `REGISTRATION_ENABLED=false` in `.env` silently does nothing on the standard Docker deployment: the endpoint keeps creating accounts, and the link stays visible.

The CasaOS, runtipi and Unraid packagings already wire it — this brings the main compose file in line.

## Changes

- **server**: add `REGISTRATION_ENABLED` to the `environment` block
- **client**: pass `VITE_REGISTRATION_ENABLED` as a build arg, and declare the matching `ARG`/`ENV` in `client/Dockerfile` next to the other `VITE_*` args

A single `REGISTRATION_ENABLED` variable drives both sides, so the UI always matches what the API accepts.

## Compatibility

Both default to `true`, so existing deployments are unaffected.

```
$ REGISTRATION_ENABLED=false docker compose config | grep REGISTRATION
        VITE_REGISTRATION_ENABLED: "false"
      REGISTRATION_ENABLED: "false"

$ docker compose config | grep REGISTRATION
        VITE_REGISTRATION_ENABLED: "true"
      REGISTRATION_ENABLED: "true"
```

Note: the client flag is read at build time by Vite, so changing it requires rebuilding the image — noted in a comment in the Dockerfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lnj9icjjSK6yuKvQ9KmagS
