### PR TITLE
fix(deps): pin qs to 6.16.0, closing two advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8515,9 +8515,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "serialize-javascript": "7.0.5",
     "@babel/core": "^7.29.6",
     "esbuild": "^0.28.1",
-    "body-parser": "^1.20.6"
+    "body-parser": "^1.20.6",
+    "qs": "^6.16.0"
   },
   "engines": {
     "node": ">=20.0.0",


### PR DESCRIPTION
Two advisories landed on `qs` 6.15.3 between the last green run and the merges of #87 and #88, so `main` went red on the production audit gate rather than on anything either pull request did.

npm proposes body-parser 2 and Express 5, both major, to reach a clean tree. `qs` 6.16.0 is outside the affected range on its own, so an override pins it under the Express 4 line we already run, the same way `serialize-javascript` and `body-parser` are already pinned.

`qs` parses query strings for Express and the fix changes how bracket keys with commas and the array limit behave, so the smoke suite matters more than usual here.

Locally: audit gate green, shared/server/client all build, lockfile keeps its 26 Linux and macOS optional binaries.