### PR TITLE
feat(ai): Google Gemini as an AI provider (#85)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ can shift based on feedback — issues and discussions are welcome.
   flow, pocket-money page (balances, streaks, adjust/redeem), savings goals with
   progress bars and a dedicated kid view.
 - **Local-first AI assistant** *(v1.2, first slice)* — provider abstraction
-  (Ollama / OpenAI-compatible / Anthropic, bring-your-own-key, keys encrypted at
+  (Ollama / OpenAI-compatible / Anthropic / Google Gemini, bring-your-own-key, keys encrypted at
   rest): natural-language input (Ctrl+K) that turns a sentence into tasks,
   appointments, shopping items or budget entries, and automatic weekly dinner
   suggestions from the recipe library.

--- a/client/src/i18n/locales/en/ai.json
+++ b/client/src/i18n/locales/en/ai.json
@@ -42,7 +42,8 @@
     "providers": {
       "ollama": "Ollama (local)",
       "openai": "OpenAI-compatible API",
-      "anthropic": "Anthropic Claude"
+      "anthropic": "Anthropic Claude",
+      "gemini": "Google Gemini"
     },
     "baseUrl": "Server URL",
     "apiKey": "API key",

--- a/client/src/i18n/locales/fr/ai.json
+++ b/client/src/i18n/locales/fr/ai.json
@@ -42,7 +42,8 @@
     "providers": {
       "ollama": "Ollama (local)",
       "openai": "API compatible OpenAI",
-      "anthropic": "Anthropic Claude"
+      "anthropic": "Anthropic Claude",
+      "gemini": "Google Gemini"
     },
     "baseUrl": "URL du serveur",
     "apiKey": "Clé API",

--- a/client/src/i18n/locales/pt/ai.json
+++ b/client/src/i18n/locales/pt/ai.json
@@ -42,7 +42,8 @@
     "providers": {
       "ollama": "Ollama (Local / Autohospedado)",
       "openai": "API compatível com OpenAI (OpenAI, Gemini, Groq, DeepSeek...)",
-      "anthropic": "Anthropic Claude"
+      "anthropic": "Anthropic Claude",
+      "gemini": "Google Gemini"
     },
     "baseUrl": "URL do Servidor / Endpoint",
     "apiKey": "Chave de API (API Key)",

--- a/client/src/i18n/locales/ru/ai.json
+++ b/client/src/i18n/locales/ru/ai.json
@@ -42,7 +42,8 @@
     "providers": {
       "ollama": "Ollama (локально)",
       "openai": "OpenAI-совместимый API",
-      "anthropic": "Anthropic Claude"
+      "anthropic": "Anthropic Claude",
+      "gemini": "Google Gemini"
     },
     "baseUrl": "Адрес сервера",
     "apiKey": "API-ключ",

--- a/client/src/i18n/locales/zh/ai.json
+++ b/client/src/i18n/locales/zh/ai.json
@@ -42,7 +42,8 @@
     "providers": {
       "ollama": "Ollama（本地）",
       "openai": "OpenAI 兼容 API",
-      "anthropic": "Anthropic Claude"
+      "anthropic": "Anthropic Claude",
+      "gemini": "Google Gemini"
     },
     "baseUrl": "服务器 URL",
     "apiKey": "API 密钥",

--- a/client/src/lib/aiStatus.ts
+++ b/client/src/lib/aiStatus.ts
@@ -6,7 +6,7 @@ import { api } from './api';
 export interface AiStatus {
     configured: boolean;
     enabled: boolean;
-    provider?: 'ollama' | 'openai' | 'anthropic';
+    provider?: 'ollama' | 'openai' | 'anthropic' | 'gemini';
     base_url?: string | null;
     model?: string;
     has_api_key?: boolean;

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -38,18 +38,20 @@ const CURRENCIES = [
     { code: 'BRL', label: 'Brazilian Real (R$)' },
 ];
 
-type AiProvider = 'ollama' | 'openai' | 'anthropic';
+type AiProvider = 'ollama' | 'openai' | 'anthropic' | 'gemini';
 
 const AI_MODEL_PLACEHOLDERS: Record<AiProvider, string> = {
     ollama: 'llama3.1',
     openai: 'gpt-4o-mini',
     anthropic: 'claude-opus-4-8',
+    gemini: 'gemini-3.8-flash',
 };
 
 const AI_BASE_URL_PLACEHOLDERS: Record<AiProvider, string> = {
     ollama: 'http://localhost:11434',
     openai: 'https://api.openai.com',
     anthropic: '',
+    gemini: '',
 };
 
 interface AiSettingsData {
@@ -122,7 +124,7 @@ const AiAssistantCard: React.FC<{ isParent: boolean }> = ({ isParent }) => {
             const trimmedKey = apiKey.trim();
             const response = await api.put<{ success: boolean; data: AiSettingsData }>('/api/ai/settings', {
                 provider,
-                base_url: provider === 'anthropic' ? null : baseUrl.trim() || null,
+                base_url: provider === 'anthropic' || provider === 'gemini' ? null : baseUrl.trim() || null,
                 // '' keeps the stored key, explicit null clears it.
                 api_key: trimmedKey ? trimmedKey : apiKeyCleared ? null : '',
                 model: model.trim(),
@@ -149,7 +151,7 @@ const AiAssistantCard: React.FC<{ isParent: boolean }> = ({ isParent }) => {
         try {
             const response = await api.post<{ success: boolean; message?: string }>('/api/ai/test', {
                 provider,
-                base_url: provider === 'anthropic' ? undefined : baseUrl.trim() || undefined,
+                base_url: provider === 'anthropic' || provider === 'gemini' ? undefined : baseUrl.trim() || undefined,
                 api_key: apiKey.trim() || undefined,
                 model: model.trim() || undefined,
             });
@@ -165,6 +167,7 @@ const AiAssistantCard: React.FC<{ isParent: boolean }> = ({ isParent }) => {
         { value: 'ollama', label: t('ai:settings.providers.ollama') },
         { value: 'openai', label: t('ai:settings.providers.openai') },
         { value: 'anthropic', label: t('ai:settings.providers.anthropic') },
+        { value: 'gemini', label: t('ai:settings.providers.gemini') },
     ];
 
     return (
@@ -209,7 +212,7 @@ const AiAssistantCard: React.FC<{ isParent: boolean }> = ({ isParent }) => {
                                     )}
                                 </div>
 
-                                {provider !== 'anthropic' && (
+                                {provider !== 'anthropic' && provider !== 'gemini' && (
                                     <Input
                                         label={t('ai:settings.baseUrl')}
                                         value={baseUrl}
@@ -229,7 +232,13 @@ const AiAssistantCard: React.FC<{ isParent: boolean }> = ({ isParent }) => {
                                                 setApiKey(e.target.value);
                                                 setTestResult(null);
                                             }}
-                                            placeholder={hasApiKey && !apiKeyCleared ? t('ai:settings.keyKept') : 'sk-…'}
+                                            placeholder={
+                                                hasApiKey && !apiKeyCleared
+                                                    ? t('ai:settings.keyKept')
+                                                    : provider === 'gemini'
+                                                        ? 'AIza…'
+                                                        : 'sk-…'
+                                            }
                                             disabled={!isParent}
                                             autoComplete="off"
                                         />

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -458,7 +458,7 @@ export const runMigrations = async () => {
         `CREATE TABLE IF NOT EXISTS ai_settings (
             id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
             user_id UUID UNIQUE NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-            provider VARCHAR(20) NOT NULL CHECK (provider IN ('ollama', 'openai', 'anthropic')),
+            provider VARCHAR(20) NOT NULL CHECK (provider IN ('ollama', 'openai', 'anthropic', 'gemini')),
             base_url TEXT,
             encrypted_api_key TEXT,
             model VARCHAR(100) NOT NULL,
@@ -608,6 +608,23 @@ export const runMigrations = async () => {
             PRIMARY KEY (post_id, user_id)
         )`,
         'CREATE INDEX IF NOT EXISTS idx_family_post_seen_user ON family_post_seen(user_id)',
+        // Migration 027: Google Gemini as an AI provider. A fresh install gets the
+        // wider CHECK from the CREATE TABLE above; an existing one still carries
+        // the three-provider constraint, which Postgres named
+        // ai_settings_provider_check. Swap it once, only when it lacks gemini.
+        `DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'ai_settings_provider_check'
+                  AND pg_get_constraintdef(oid) NOT ILIKE '%gemini%'
+            ) THEN
+                ALTER TABLE ai_settings DROP CONSTRAINT ai_settings_provider_check;
+                ALTER TABLE ai_settings ADD CONSTRAINT ai_settings_provider_check
+                    CHECK (provider IN ('ollama', 'openai', 'anthropic', 'gemini'));
+            END IF;
+        END
+        $$`,
     ];
 
     for (const migration of migrations) {

--- a/server/src/routes/ai.ts
+++ b/server/src/routes/ai.ts
@@ -23,7 +23,7 @@ import logger from '../lib/logger';
 const router = Router();
 router.use(authMiddleware);
 
-const PROVIDERS: AiProvider[] = ['ollama', 'openai', 'anthropic'];
+const PROVIDERS: AiProvider[] = ['ollama', 'openai', 'anthropic', 'gemini'];
 
 interface AiSettingsRow {
     provider: AiProvider;
@@ -113,9 +113,9 @@ router.put('/settings', requireParent, async (req: AuthRequest, res) => {
             return res.status(400).json({ success: false, error: 'model est requis' });
         }
 
-        // Anthropic uses the official endpoint — no base URL to store.
+        // Anthropic and Gemini use their official endpoints — no base URL to store.
         let cleanedBaseUrl: string | null = null;
-        if (provider !== 'anthropic') {
+        if (provider !== 'anthropic' && provider !== 'gemini') {
             const rawUrl = typeof base_url === 'string' ? base_url.trim().replace(/\/+$/, '') : '';
             if (rawUrl) {
                 try {

--- a/server/src/services/ai/gemini.ts
+++ b/server/src/services/ai/gemini.ts
@@ -1,0 +1,131 @@
+// Google Gemini provider — direct REST call to the Gemini API, no SDK.
+//
+// The key travels in the x-goog-api-key header and never in the URL, so it
+// cannot end up in a proxy or access log. Structured output is requested with
+// the same JSON schema the other providers receive (responseJsonSchema takes
+// standard JSON Schema, including additionalProperties:false), so Gemini plugs
+// into the same validated completion pipeline.
+
+import {
+    AiError,
+    aiFetch,
+    extractJson,
+    type AiSettings,
+    type AiCompletionRequest,
+    type TokenUsage,
+} from './index';
+
+const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
+
+export async function geminiComplete(
+    settings: AiSettings,
+    request: AiCompletionRequest
+): Promise<{ data: Record<string, unknown>; usage: TokenUsage | null }> {
+    if (!settings.api_key) {
+        throw new AiError('AI_UNAUTHORIZED', 'Clé API Google Gemini manquante');
+    }
+
+    const model = settings.model.trim();
+    if (!model) {
+        throw new AiError('AI_MODEL_NOT_FOUND', 'Modèle Gemini manquant');
+    }
+
+    const url = `${GEMINI_API_BASE}/models/${encodeURIComponent(model)}:generateContent`;
+
+    const response = await aiFetch(url, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'x-goog-api-key': settings.api_key,
+        },
+        body: JSON.stringify({
+            system_instruction: { parts: [{ text: request.system }] },
+            contents: [{ role: 'user', parts: [{ text: request.user }] }],
+            generationConfig: {
+                responseMimeType: 'application/json',
+                responseJsonSchema: request.jsonSchema,
+            },
+        }),
+    });
+
+    if (!response.ok) {
+        const { message, status, reason } = await readError(response);
+
+        // A bad key is NOT a 401 on this API: Google answers 400 INVALID_ARGUMENT
+        // with reason API_KEY_INVALID (verified against the live endpoint), so the
+        // structured status and reason are checked before the HTTP code.
+        if (
+            response.status === 401 ||
+            response.status === 403 ||
+            reason === 'API_KEY_INVALID' ||
+            status === 'UNAUTHENTICATED' ||
+            status === 'PERMISSION_DENIED'
+        ) {
+            throw new AiError('AI_UNAUTHORIZED', message || 'Clé API Google Gemini refusée');
+        }
+        // Unknown model: 404 NOT_FOUND, "models/x is not found for API version
+        // v1beta, or is not supported for generateContent".
+        if (
+            response.status === 404 ||
+            status === 'NOT_FOUND' ||
+            (/model/i.test(message) && /not found|not supported|does not exist/i.test(message))
+        ) {
+            throw new AiError('AI_MODEL_NOT_FOUND', message || `Modèle Gemini introuvable: ${model}`);
+        }
+        throw new AiError('AI_PROVIDER_ERROR', message || `Google Gemini a répondu HTTP ${response.status}`);
+    }
+
+    const body = (await response.json().catch(() => null)) as {
+        candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
+        usageMetadata?: {
+            promptTokenCount?: number;
+            candidatesTokenCount?: number;
+            totalTokenCount?: number;
+        };
+    } | null;
+
+    const parts = body?.candidates?.[0]?.content?.parts ?? [];
+    const content = parts
+        .map((part) => (typeof part.text === 'string' ? part.text : ''))
+        .join('')
+        .trim();
+
+    if (!content) {
+        throw new AiError('AI_INVALID_RESPONSE', 'Réponse Google Gemini vide');
+    }
+
+    // Structured output already guarantees valid JSON, but stay defensive anyway.
+    const result = extractJson(content);
+
+    const usage = body?.usageMetadata
+        ? {
+              prompt_tokens: body.usageMetadata.promptTokenCount ?? 0,
+              completion_tokens: body.usageMetadata.candidatesTokenCount ?? 0,
+              total_tokens: body.usageMetadata.totalTokenCount ?? 0,
+          }
+        : null;
+
+    return { data: result, usage };
+}
+
+/**
+ * Google's error envelope: { error: { code, status, message, details: [...] } }
+ * where details may carry a google.rpc.ErrorInfo with a machine-readable reason.
+ * Everything is optional and the body may not be JSON at all.
+ */
+async function readError(response: Response): Promise<{ message: string; status: string; reason: string }> {
+    try {
+        const body = (await response.json()) as {
+            error?: { message?: string; status?: string; details?: Array<{ reason?: string }> };
+        };
+        const error = body?.error;
+        const info = error?.details?.find((d) => typeof d?.reason === 'string');
+        return {
+            message: typeof error?.message === 'string' ? error.message : '',
+            status: typeof error?.status === 'string' ? error.status : '',
+            reason: info?.reason ?? '',
+        };
+    } catch {
+        return { message: '', status: '', reason: '' };
+    }
+}

--- a/server/src/services/ai/index.ts
+++ b/server/src/services/ai/index.ts
@@ -2,20 +2,21 @@
 //
 // A single entry point, aiComplete(), takes a system prompt, a user prompt and
 // a JSON schema, dispatches to the configured provider (Ollama / OpenAI-compatible /
-// Anthropic) and returns a PARSED JSON object. The model output is never trusted:
+// Anthropic / Google Gemini) and returns a PARSED JSON object. The model output is never trusted:
 // callers must still structurally validate the result.
 
 import { ollamaComplete } from './ollama';
 import { openaiComplete } from './openai';
 import { anthropicComplete } from './anthropic';
+import { geminiComplete } from './gemini';
 
-export type AiProvider = 'ollama' | 'openai' | 'anthropic';
+export type AiProvider = 'ollama' | 'openai' | 'anthropic' | 'gemini';
 
 export interface AiSettings {
     provider: AiProvider;
-    /** Base URL (ollama / openai-compatible only — ignored for anthropic). */
+    /** Base URL (ollama / openai-compatible only — ignored for anthropic and gemini). */
     base_url: string | null;
-    /** Decrypted API key (openai / anthropic — never needed for ollama). */
+    /** Decrypted API key (openai / anthropic / gemini — never needed for ollama). */
     api_key: string | null;
     model: string;
 }
@@ -48,6 +49,7 @@ export const DEFAULT_BASE_URLS: Record<AiProvider, string | null> = {
     ollama: 'http://localhost:11434',
     openai: 'https://api.openai.com',
     anthropic: null,
+    gemini: null,
 };
 
 /**
@@ -130,6 +132,8 @@ export async function aiCompleteWithUsage(
             return openaiComplete(settings, request);
         case 'anthropic':
             return anthropicComplete(settings, request);
+        case 'gemini':
+            return geminiComplete(settings, request);
         default:
             throw new AiError('AI_PROVIDER_ERROR', `Fournisseur IA inconnu: ${settings.provider}`);
     }


### PR DESCRIPTION
Port of the Google Gemini provider from @thecybermacgyver's community enhancement batch (issue #85, "UI refinements and Gemini" package). Only the Gemini part is in this PR; the UI refinements from the same package will come separately.

**What it adds**

- `gemini` as a fourth AI provider, next to Ollama, OpenAI-compatible and Anthropic. Direct REST call to `generateContent`, key in the `x-goog-api-key` header, structured output through `responseJsonSchema` with the same schema the other providers get.
- Settings page: Gemini in the provider list, no base URL field (like Anthropic), `AIza…` key placeholder, `gemini-3.8-flash` model placeholder.
- Migration 027: widens the `ai_settings` provider CHECK constraint on existing installations. His `server/migrations/006_*.sql` is folded into `db.ts`, since the server owns the schema since #93.
- Labels in the five interface languages.

**Fixed while porting**

Google answers a bad key with HTTP 400 `INVALID_ARGUMENT` / reason `API_KEY_INVALID`, not 401. The original mapping only caught 401/403, so a wrong key surfaced as a generic provider error. The provider now reads Google's structured `status` and `reason` before the HTTP code.

**Verified**

- 24 unit checks with a stubbed `fetch`: request shape, header placement, schema passthrough, model name encoding, fenced and multi-part answers, every error mapping (including Google's real invalid-key body), guard clauses never reaching the network.
- 9 live checks on a database created by `main` and then upgraded by this branch: constraint swapped by migration 027, settings stored and read back, base URL dropped for Gemini, unknown provider still refused, and a real call to Google with a bad key coming back as `AI_UNAUTHORIZED`.
- Fresh install converges to the same constraint; server log clean.
- `tsc` clean on server and client, i18n parity full, public-safety check passing.

Refs #85
